### PR TITLE
Use gcc visibility attribute and Q_DECL_EXPORT macro to avoid exporting internal symbols.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,12 @@ set (MINOR_VERSION 0)
 set (PATCH_VERSION 0)
 set(QTXDG_VERSION_STRING ${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION})
 
-add_definitions(-Wall)
+add_definitions(-Wall -DQTXDG_COMPILATION=1)
+
+if (CMAKE_COMPILER_IS_GNUCXX)
+    # set visibility to hidden to hide symbols, unless they're exported manually in the code
+    set(CMAKE_CXX_FLAGS "-fvisibility=hidden -fvisibility-inlines-hidden -fno-exceptions ${CMAKE_CXX_FLAGS}")
+endif()
 
 find_package(PkgConfig)
 

--- a/xdgaction.h
+++ b/xdgaction.h
@@ -30,6 +30,7 @@
 #ifndef QTXDG_XDGACTION_H
 #define QTXDG_XDGACTION_H
 
+#include "xdgmacros.h"
 #include "xdgdesktopfile.h"
 
 #include <QAction>
@@ -52,7 +53,7 @@
   the application defined in XdgDesktopFile. @sa XdgDesktopFile::startDetached.
 ****************************************/
 //*******************************************************************
-class XdgAction : public QAction
+class QTXDG_API XdgAction : public QAction
 {
     Q_OBJECT
 public:

--- a/xdgautostart.h
+++ b/xdgautostart.h
@@ -29,6 +29,7 @@
 #ifndef QTXDG_XDGAUTOSTART_H
 #define QTXDG_XDGAUTOSTART_H
 
+#include "xdgmacros.h"
 #include "xdgdesktopfile.h"
 
 /*! @brief The XdgAutoStart class implements the "Desktop Application Autostart Specification"
@@ -39,7 +40,7 @@
  *
  * @sa http://standards.freedesktop.org/autostart-spec/autostart-spec-latest.html
  */
-class XdgAutoStart
+class QTXDG_API XdgAutoStart
 {
 public:
     /*! Returns a list of XdgDesktopFile objects for all the .desktop files in the Autostart directories

--- a/xdgdesktopfile.h
+++ b/xdgdesktopfile.h
@@ -56,7 +56,7 @@ class XdgDesktopFileData;
  \author Alexander Sokoloff <sokoloff.a@gmail.com>
  */
 
-class XdgDesktopFile
+class QTXDG_API XdgDesktopFile
 {
 public:
     /*! The Desktop Entry Specification defines 3 types of desktop entries: Application, Link and
@@ -222,7 +222,7 @@ private:
 typedef QList<XdgDesktopFile> XdgDesktopFileList;
 
 
-class XdgDesktopFileCache
+class QTXDG_API XdgDesktopFileCache
 {
 public:
     static XdgDesktopFile* getFile(const QString& fileName);

--- a/xdgdirs.h
+++ b/xdgdirs.h
@@ -30,6 +30,7 @@
 #ifndef QTXDG_XDGDIRS_H
 #define QTXDG_XDGDIRS_H
 
+#include "xdgmacros.h"
 #include <QString>
 #include <QStringList>
 
@@ -52,7 +53,7 @@ static const QString userDirectoryString[8] =
     "Videos"
 };
 
-class XdgDirs
+class QTXDG_API XdgDirs
 {
 public:
     enum UserDirectory

--- a/xdgicon.h
+++ b/xdgicon.h
@@ -30,11 +30,12 @@
 #ifndef QTXDG_XDGICON_H
 #define QTXDG_XDGICON_H
 
+#include "xdgmacros.h"
 #include <QtGui/QIcon>
 #include <QString>
 #include <QStringList>
 
-class XdgIcon
+class QTXDG_API XdgIcon
 {
 public:
     static QIcon fromTheme(const QString& iconName, const QIcon& fallback = QIcon());

--- a/xdgmacros.h
+++ b/xdgmacros.h
@@ -28,4 +28,10 @@
 #  endif
 #endif
 
+#ifdef QTXDG_COMPILATION
+    #define QTXDG_API    Q_DECL_EXPORT
+#else
+    #define QTXDG_API    Q_DECL_IMPORT
+#endif
+
 #endif // QTXDG_MACROS_H

--- a/xdgmenu.h
+++ b/xdgmenu.h
@@ -30,6 +30,7 @@
 #ifndef QTXDG_XDGMENU_H
 #define QTXDG_XDGMENU_H
 
+#include "xdgmacros.h"
 #include <QObject>
 #include <QString>
 #include <QStringList>
@@ -62,7 +63,7 @@ class XdgMenuPrivate;
  @sa http://specifications.freedesktop.org/menu-spec/menu-spec-latest.html
  */
 
-class XdgMenu : public QObject
+class QTXDG_API XdgMenu : public QObject
 {
 Q_OBJECT
     friend class XdgMenuReader;

--- a/xdgmenuwidget.h
+++ b/xdgmenuwidget.h
@@ -29,6 +29,7 @@
 #ifndef QTXDG_XDGMENUWIDGET_H
 #define QTXDG_XDGMENUWIDGET_H
 
+#include "xdgmacros.h"
 #include <QMenu>
 #include <QtXml/QDomElement>
 
@@ -58,7 +59,7 @@ class XdgMenuWidgetPrivate;
  @endcode
  */
 
-class XdgMenuWidget : public QMenu
+class QTXDG_API XdgMenuWidget : public QMenu
 {
     Q_OBJECT
 public:

--- a/xdgmime.h
+++ b/xdgmime.h
@@ -39,7 +39,7 @@ struct XdgMimeData;
 
 /*! @brief The XdgMimeInfo class provides mime information about file.
  */
-class QTXDG_DEPRECATED XdgMimeInfo
+class QTXDG_DEPRECATED QTXQD_API XdgMimeInfo
 {
 public:
     /// Constructs a XdgMimeInfo with the mimeType type.
@@ -84,7 +84,7 @@ private:
 };
 
 
-class QTXDG_DEPRECATED XdgMimeInfoCache
+class QTXDG_DEPRECATED QTXDG_API XdgMimeInfoCache
 {
 public:
     static QStringList mediatypes();

--- a/xdgmimetype.h
+++ b/xdgmimetype.h
@@ -21,6 +21,7 @@
 #ifndef QTXDG_MIMETYPE_H
 #define QTXDG_MIMETYPE_H
 
+#include "xdgmacros.h"
 #include <QMimeType>
 #include <QIcon>
 #include <QString>
@@ -40,7 +41,7 @@ class XdgMimeTypePrivate;
  * @author Luís Pereira (luis.artur.pereira@gmail.com)
  */
 
-class XdgMimeType : public QMimeType {
+class QTXDG_API XdgMimeType : public QMimeType {
 public:
 
     /*! Constructs an XdgMimeType object initialized with default property

--- a/xmlhelper.h
+++ b/xmlhelper.h
@@ -29,11 +29,12 @@
 #ifndef QTXDG_XMLHELPER_H
 #define QTXDG_XMLHELPER_H
 
+#include "xdgmacros.h"
 #include <QDebug>
 #include <QtXml/QDomElement>
 #include <QtXml/QDomNode>
 
-class DomElementIterator
+class QTXDG_API DomElementIterator
 {
 public:
     explicit DomElementIterator(const QDomNode& parentNode, const QString& tagName="")


### PR DESCRIPTION
This greatly reduced the size of dynamic symbol table and might potentially speed up loading.
Also, turn off exception handling to save more since we don't use it.
For non-gcc compilers, this change does nothing.
@luis-pereira please see if this is OK for you. :-)
Thanks!