### PR TITLE
Fixes XdgDesktop::isShow() caching mechanism

### DIFF
--- a/xdgdesktopfile.cpp
+++ b/xdgdesktopfile.cpp
@@ -298,7 +298,7 @@ public:
     QString mFileName;
     bool mIsValid;
     mutable bool mValidIsChecked;
-    mutable Triple mIsShow;
+    mutable QHash<QString, bool> mIsShow;
     QMap<QString, QVariant> mItems;
 
     XdgDesktopFile::Type mType;
@@ -310,8 +310,7 @@ public:
  ************************************************/
 XdgDesktopFileData::XdgDesktopFileData():
     mIsValid(false),
-    mValidIsChecked(false),
-    mIsShow(Undef)
+    mValidIsChecked(false)
 {
 }
 
@@ -1168,37 +1167,43 @@ bool checkTryExec(const QString& progName)
  ************************************************/
 bool XdgDesktopFile::isShow(const QString& environment) const
 {
-    if (d->mIsShow != Undef)
-        return d->mIsShow == True;
+    const QString env = environment.toUpper();
 
-    d->mIsShow = False;
+    if (d->mIsShow.contains(env))
+        return d->mIsShow.value(env);
+
+    d->mIsShow.insert(env, false);
     // Means "this application exists, but don't display it in the menus".
     if (value("NoDisplay").toBool())
         return false;
 
     // The file is inapplicable to the current environment
-    if (!isSuitable(true, environment))
+    if (!isSuitable(true, env))
         return false;
 
-    d->mIsShow = True;
+
+    d->mIsShow.insert(env, true);
     return true;
 }
 
 bool XdgDesktopFile::isShown(const QString &environment) const
 {
-    if (d->mIsShow != Undef)
-        return d->mIsShow == True;
+    const QString env = environment.toUpper();
 
-    d->mIsShow = False;
+    if (d->mIsShow.contains(env))
+        return d->mIsShow.value(env);
+
+    d->mIsShow.insert(env, false);
+
     // Means "this application exists, but don't display it in the menus".
     if (value("NoDisplay").toBool())
         return false;
 
     // The file is not suitable to the current environment
-    if (!isSuitable(true, environment))
+    if (!isSuitable(true, env))
         return false;
 
-    d->mIsShow = True;
+    d->mIsShow.insert(env, true);
     return true;
 }
 

--- a/xdgdesktopfile.cpp
+++ b/xdgdesktopfile.cpp
@@ -280,12 +280,6 @@ QString &unEscapeExec(QString& str)
     return doUnEscape(str, repl);
 }
 
-enum Triple {
-    Undef,
-    True,
-    False
-};
-
 class XdgDesktopFileData: public QSharedData {
 public:
     XdgDesktopFileData();


### PR DESCRIPTION
The cache mechanism was totally broken. It stored the last mIsShow value.
And that's it. It didn't take into account the environment.
It didn't work with straightforward code like this:
for (int i = 0; i < N; ++i)
{
    if (file->isShown(envs.at(i)))
    {
        show = true;
        break;
    }
}

Closes lxde/lxqt#563