### PR TITLE
Backports Fixed icons lookup in QIcon::fromTheme

### DIFF
--- a/qiconfix/qiconloader_p.h
+++ b/qiconfix/qiconloader_p.h
@@ -107,6 +107,12 @@ struct PixmapEntry : public QIconLoaderEngineEntry
 
 typedef QList<QIconLoaderEngineEntry*> QThemeIconEntries;
 
+struct QThemeIconInfo
+{
+    QThemeIconEntries entries;
+    QString iconName;
+};
+
 //class QIconLoaderEngine : public QIconEngine
 class QIconLoaderEngineFixed : public QIconEngine
 {
@@ -128,7 +134,7 @@ private:
     void virtual_hook(int id, void *data);
     QIconLoaderEngineEntry *entryForSize(const QSize &size);
     QIconLoaderEngineFixed(const QIconLoaderEngineFixed &other);
-    QThemeIconEntries m_entries;
+    QThemeIconInfo m_info;
     QString m_iconName;
     uint m_key;
 
@@ -142,12 +148,10 @@ public:
     QIconTheme() : m_valid(false) {}
     QStringList parents() { return m_parents; }
     QVector <QIconDirInfo> keyList() { return m_keyList; }
-    QString contentDir() { return m_contentDir; }
     QStringList contentDirs() { return m_contentDirs; }
     bool isValid() { return m_valid; }
 
 private:
-    QString m_contentDir;
     QStringList m_contentDirs;
     QVector <QIconDirInfo> m_keyList;
     QStringList m_parents;
@@ -158,7 +162,7 @@ class Q_GUI_EXPORT QIconLoader
 {
 public:
     QIconLoader();
-    QThemeIconEntries loadIcon(const QString &iconName) const;
+    QThemeIconInfo loadIcon(const QString &iconName) const;
     uint themeKey() const { return m_themeKey; }
 
     QString themeName() const { return m_userTheme.isEmpty() ? m_systemTheme : m_userTheme; }
@@ -173,9 +177,9 @@ public:
     void ensureInitialized();
 
 private:
-    QThemeIconEntries findIconHelper(const QString &themeName,
-                                     const QString &iconName,
-                                     QStringList &visited) const;
+    QThemeIconInfo findIconHelper(const QString &themeName,
+                                  const QString &iconName,
+                                  QStringList &visited) const;
     uint m_themeKey;
     bool m_supportsSvg;
     bool m_initialized;


### PR DESCRIPTION
We already supported multile directories. But we didn't support dashes to
separate levels of specificity in icon names.
Closes lxde/libqtxdg#54.

QIconloader upstream commit:
https://qt.gitorious.org/qt/qtbase/commit/a40d390a3bbc1919843000b427a168180b83a344

Upstream commit message:
This commit fixes incorrect logic of icons' lookup if there are
fallbacks or more than one theme's directory.

According to Icon Theme Specification, Directory Layout section, theme
can be spread across several base directories by having subdirectories
of the same name. This makes possible to extend system themes by
application-specific icons without making of collisions with other
applications.

According to Icon Naming Specification, Icon Naming Guidelines section,
icon name may contain dashes to separate levels of specificity in icon
names. This makes possible to set in application very specific icon
which may be not in every theme. So it can fallback to less specific one.