### PR TITLE
CMake: Adds Runtime install COMPONENT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ endforeach()
 install(TARGETS
     ${QTXDGX_LIBRARY_NAME} DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     EXPORT "${QTXDGX_FILE_NAME}-targets"
+    COMPONENT Runtime
 )
 
 install(EXPORT


### PR DESCRIPTION
There are two install components:
    * Devel Contains all the development files;
    * Runtime Contains all the runtime needed files.

It's possible to install:
  - Everything: make install OR cmake -P cmake_install.cmake
  - Development files only: cmake -DCOMPONENT=Devel -P cmake_install.cmake
  - Runtime files only: cmake -DCOMPONENT=Runtime -P cmake_install.cmake

This COMPONENT's can also be used with CPack.