### PR TITLE
xdgdesktopfile: handle 'Path' entry for application's working directory

### DIFF
--- a/xdgdesktopfile.cpp
+++ b/xdgdesktopfile.cpp
@@ -383,12 +383,17 @@ bool XdgDesktopFileData::startApplicationDetached(const XdgDesktopFile *q, const
     }
 
     QString cmd = args.takeFirst();
+    QString workingDir = q->value("Path").toString();
+    if (!workingDir.isEmpty() && !QDir(workingDir).exists())
+	    workingDir = QString();
 
     if (nonDetach)
     {
         QScopedPointer<QProcess> p(new QProcess);
         p->setStandardInputFile(QProcess::nullDevice());
         p->setProcessChannelMode(QProcess::ForwardedChannels);
+        if (!workingDir.isEmpty())
+            p->setWorkingDirectory(workingDir);
         p->start(cmd, args);
         bool started = p->waitForStarted();
         if (started)
@@ -400,7 +405,7 @@ bool XdgDesktopFileData::startApplicationDetached(const XdgDesktopFile *q, const
     }
     else
     {
-        return QProcess::startDetached(cmd, args);
+        return QProcess::startDetached(cmd, args, workingDir);
     }
 }
 


### PR DESCRIPTION
it is an optional enty of the specification [1]

http://standards.freedesktop.org/desktop-entry-spec/latest/ar01s05.html

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>