### PR TITLE
XdgUserDirs: Return a fallback when the path is empty

### DIFF
--- a/xdgdirs.cpp
+++ b/xdgdirs.cpp
@@ -137,6 +137,8 @@ QString XdgDirs::userDir(XdgDirs::UserDirectory dir)
 
             // get path between quotes
             line = line.section(QLatin1Char('"'), 1, 1);
+            if (line.isEmpty())
+                return fallback;
             line.replace(QLatin1String("$HOME"), QLatin1String("~"));
             fixBashShortcuts(line);
             return line;


### PR DESCRIPTION
If the path to the folder is empty we return the default value.
It's what xdg-user-dirs also do.