### PR TITLE
Adds an .desktop file start tester

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ create_pkgconfig_file(
 
 target_compile_definitions(${QTXDGX_LIBRARY_NAME}
     PRIVATE "QTXDG_COMPILATION=\"1\""
+    PRIVATE "QTXDG_VERSION=\"${QTXDG_VERSION_STRING}\""
 )
 
 target_include_directories(${QTXDGX_LIBRARY_NAME}
@@ -258,6 +259,8 @@ else()
     message(STATUS "For building tests use -DBUILD_TESTS=Yes option.")
     message(STATUS "")
 endif()
+
+add_subdirectory(util)
 
 # uninstall target
 configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)
 project(libqtxdg)
 
 option(BUILD_TESTS "Builds tests" OFF)
+option(BUILD_DEV_UTILS "Builds and install development utils" OFF)
 
 # additional cmake files
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
@@ -260,7 +261,9 @@ else()
     message(STATUS "")
 endif()
 
-add_subdirectory(util)
+if (BUILD_DEV_UTILS)
+    add_subdirectory(util)
+endif()
 
 # uninstall target
 configure_file(

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,0 +1,26 @@
+include_directories (
+    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+set(QTXDG_DESKTOP_FILE_START_SRCS
+    qtxdg-desktop-file-start.cpp
+)
+
+add_executable(qtxdg-desktop-file-start
+    ${QTXDG_DESKTOP_FILE_START_SRCS}
+)
+
+target_compile_definitions(qtxdg-desktop-file-start
+    PRIVATE "-DQTXDG_VERSION=\"${QTXDG_VERSION_STRING}\""
+)
+
+target_link_libraries(qtxdg-desktop-file-start
+    ${QTXDGX_LIBRARY_NAME}
+)
+
+install(TARGETS
+    qtxdg-desktop-file-start
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    COMPONENT Runtime
+)

--- a/util/qtxdg-desktop-file-start.cpp
+++ b/util/qtxdg-desktop-file-start.cpp
@@ -1,0 +1,71 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2016  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#include <QCoreApplication>
+#include <QCommandLineParser>
+#include <QFileInfo>
+
+#include <XdgDesktopFile>
+
+#include <iostream>
+
+static void printErr(const QString & out)
+{
+    std::cerr << qPrintable(out);
+}
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+    QCoreApplication::setApplicationName(QLatin1String("qtxdg-desktop-file-start"));
+    QCoreApplication::setApplicationVersion(QLatin1String(QTXDG_VERSION));
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription("QtXdg XdgDesktopFile start Tester");
+    parser.addHelpOption();
+    parser.addVersionOption();
+    parser.addPositionalArgument("file [urls...]", "desktop file to start and it's urls", "file [urls...]");
+    parser.process(app);
+
+    if (parser.positionalArguments().isEmpty()) {
+        parser.showHelp(EXIT_FAILURE);
+    }
+
+    QStringList userArgs = parser.positionalArguments();
+    const QString userFileName = userArgs.takeFirst();
+    const QFileInfo fileInfo(userFileName);
+    const QString canonicalFileName = fileInfo.canonicalFilePath();
+
+    if (!fileInfo.exists()) {
+        printErr(QString("File %1 does not exist\n").arg(userFileName));
+        return EXIT_FAILURE;
+    }
+
+    XdgDesktopFile f;
+    const bool valid = f.load(canonicalFileName);
+    if (valid) {
+        f.startDetached(userArgs);
+    } else {
+        printErr(QString("%1 is not a valid .desktop file\n").arg(canonicalFileName));
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
It allows a developer to start an .desktop file from the command line.
Closes #63.