### PR TITLE
XdgDesktopFile: Adds a Desktop File ID calculator method

### DIFF
--- a/xdgdesktopfile.cpp
+++ b/xdgdesktopfile.cpp
@@ -69,6 +69,7 @@ static const char notShowInKey[] = "NotShowIn";
 static const char categoriesKey[] = "Categories";
 static const char extendPrefixKey[] = "X-";
 static QLatin1String mimeTypeKey("MimeType");
+static const QLatin1String applicationsStr("applications");
 
 // Helper functions prototypes
 bool checkTryExec(const QString& progName);
@@ -1069,6 +1070,37 @@ bool checkTryExec(const QString& progName)
     }
 
     return false;
+}
+
+
+QString XdgDesktopFile::id(const QString &fileName, bool checkFileExists)
+{
+    const QFileInfo f(fileName);
+    if (checkFileExists) {
+        if (!f.exists()) {
+            return QString();
+        }
+    }
+
+    QString id = f.absoluteFilePath();
+    const QStringList dataDirs = XdgDirs::dataDirs();
+
+    foreach(const QString &d, dataDirs) {
+        if (id.startsWith(d)) {
+            // remove only the first occurence
+            id.replace(id.indexOf(d), d.size(), QString());
+        }
+    }
+
+    const QLatin1Char slash('/');
+    const QString s = slash + applicationsStr + slash;
+    if (!id.startsWith(s))
+        return QString();
+
+    id.replace(id.indexOf(s), s.size(), QString());
+    id.replace(slash, QLatin1Char('-'));
+
+    return id;
 }
 
 

--- a/xdgdesktopfile.h
+++ b/xdgdesktopfile.h
@@ -184,6 +184,17 @@ public:
     /*! Returns the URL for the Link desktop file; otherwise an empty string is returned.  */
     QString url() const;
 
+    /*! Computes the desktop file ID. It is the identifier of an installed
+     *  desktop entry file.
+     * @par fileName - The desktop file complete name.
+     * @par checkFileExists If true and the file doesn't exist the computed ID
+     * will be an empty QString(). Defaults to true.
+     * @return The computed ID. Returns an empty QString() if it's impossible to
+     * compute the ID. Reference:
+     * https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#desktop-file-id
+     */
+    static QString id(const QString &fileName, bool checkFileExists = true);
+
     /*! The desktop entry specification defines a number of fields to control the visibility of the application menu. This function
          checks whether to display a this application or not. */
     QTXDG_DEPRECATED bool isShow(const QString& environment = "Razor") const;


### PR DESCRIPTION
It implements the desktop-file ID calculator.
Spec:
https://specifications.freedesktop.org/desktop-entry-spec/latest/ape.html