### PR TITLE
qtxdg: Get the HOME environment variable just one time

### DIFF
--- a/qtxdg/xdgdesktopfile.cpp
+++ b/qtxdg/xdgdesktopfile.cpp
@@ -924,10 +924,12 @@ QString expandEnvVariables(const QString str)
       )
         return str;
 
-    QString res = str;
-    res.replace(QRegExp(QString::fromLatin1("~(?=$|/)")), QFile::decodeName(qgetenv("HOME")));
+    const QString homeDir = QFile::decodeName(qgetenv("HOME"));
 
-    replaceVar(res, QLatin1String("HOME"), QFile::decodeName(qgetenv("HOME")));
+    QString res = str;
+    res.replace(QRegExp(QString::fromLatin1("~(?=$|/)")), homeDir);
+
+    replaceVar(res, QLatin1String("HOME"), homeDir);
     replaceVar(res, QLatin1String("USER"), QString::fromLocal8Bit(qgetenv("USER")));
 
     replaceVar(res, QLatin1String("XDG_DESKTOP_DIR"),   XdgDirs::userDir(XdgDirs::Desktop));

--- a/qtxdg/xdgdirs.cpp
+++ b/qtxdg/xdgdirs.cpp
@@ -103,12 +103,14 @@ void cleanAndAddPostfix(QStringList &dirs, const QString& postfix)
 QString userDirFallback(XdgDirs::UserDirectory dir)
 {
     QString fallback;
-    if (QFile::decodeName(qgetenv("HOME")).isEmpty())
+    const QString home = QFile::decodeName(qgetenv("HOME"));
+
+    if (home.isEmpty())
         return QString::fromLatin1("/tmp");
     else if (dir == XdgDirs::Desktop)
-        fallback = QString::fromLatin1("%1/%2").arg(QFile::decodeName(qgetenv("HOME"))).arg(QLatin1String("Desktop"));
+        fallback = QString::fromLatin1("%1/%2").arg(home).arg(QLatin1String("Desktop"));
     else
-        fallback = QFile::decodeName(qgetenv("HOME"));
+        fallback = home;
 
     return fallback;
 }


### PR DESCRIPTION
Avoids unnecessary string conversions.