### PR TITLE
XdgDesktopFileData: Explicitly initialize members

### DIFF
--- a/qtxdg/xdgdesktopfile.cpp
+++ b/qtxdg/xdgdesktopfile.cpp
@@ -294,8 +294,12 @@ public:
 
 
 XdgDesktopFileData::XdgDesktopFileData():
+    mFileName(),
     mIsValid(false),
-    mValidIsChecked(false)
+    mValidIsChecked(false),
+    mIsShow(),
+    mItems(),
+    mType(XdgDesktopFile::UnknownType)
 {
 }
 


### PR DESCRIPTION
Explicitly initialize all members.