### PR TITLE
xdgdesktopfile: Removes an not needed debug info

### DIFF
--- a/qtxdg/xdgdesktopfile.cpp
+++ b/qtxdg/xdgdesktopfile.cpp
@@ -1554,10 +1554,7 @@ QSettings::Format XdgDesktopFileCache::desktopFileSettingsFormat()
     static QSettings::Format format = QSettings::InvalidFormat;
 
     if (format == QSettings::InvalidFormat)
-    {
         format = QSettings::registerFormat(QLatin1String("*.list"), readDesktopFile, writeDesktopFile);
-        qDebug() << "registerFormat returned:" << format;
-    }
 
     return format;
 }


### PR DESCRIPTION
It adds no value (anymore).