### PR TITLE
Fixes QIcon::hasThemeIcon() behaviour with our Icon Loader Engine

### DIFF
--- a/xdgiconloader/xdgiconloader.cpp
+++ b/xdgiconloader/xdgiconloader.cpp
@@ -693,7 +693,7 @@ void XdgIconLoaderEngine::virtual_hook(int id, void *data)
     case QIconEngine::IconNameHook:
         {
             QString &name = *reinterpret_cast<QString*>(data);
-            name = m_iconName;
+            name = m_info.iconName;
         }
         break;
     default:


### PR DESCRIPTION
It was always returning true.
Closes lxde/libqtxdg#98.
Closes lxde/lxqt#1081.