### PR TITLE
Adds Qt5Svg explicitly to the required packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ include(create_pkgconfig_file)
 include(compiler_settings NO_POLICY_SCOPE)
 
 find_package(Qt5Widgets REQUIRED QUIET)
+find_package(Qt5Svg REQUIRED QUIET)
 find_package(Qt5Xml REQUIRED QUIET)
 find_package(Qt5DBus REQUIRED QUIET)
 

--- a/xdgiconloader/CMakeLists.txt
+++ b/xdgiconloader/CMakeLists.txt
@@ -54,6 +54,7 @@ target_include_directories(${QTXDGX_ICONLOADER_LIBRARY_NAME}
 target_link_libraries(${QTXDGX_ICONLOADER_LIBRARY_NAME}
     PUBLIC
         Qt5::Gui
+        Qt5::Svg
 )
 
 set_target_properties(${QTXDGX_ICONLOADER_LIBRARY_NAME}


### PR DESCRIPTION
It was an implicit dependency as XdgIconLoader always support svg icons.
Let's make it explicit.