### PR TITLE
Updates dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
    - Qt5
 
+   ###Runtime optional dependencies:
+   * gtk-update-icon-cache
+     * **Note:** We are able now to use GTK+ icon theme caches for faster icon lookup. The cache file can be generated with gtk-update-icon-cache utility on a theme directory. If the cache is not present, corrupted, or outdated, the normal slow lookup is still run.
+
+
 ##Configuration
 
 ```libqtxdg``` uses the CMake build system. Everything that applies to CMake also


### PR DESCRIPTION
Adds gtk-update-icon-cache to the optional runtime dependencies.