### PR TITLE
test: Fixes false positive in tst_xdgdesktopfile::testReadLocalized()

### DIFF
--- a/test/tst_xdgdesktopfile.cpp
+++ b/test/tst_xdgdesktopfile.cpp
@@ -27,13 +27,13 @@ class Language
 {
 public:
     Language (const QString& lang)
-    : mPreviousLang(QString::fromLocal8Bit(qgetenv("LANG")))
+    : mPreviousLang(QString::fromLocal8Bit(qgetenv("LC_MESSAGES")))
     {
-        qputenv("LANG", lang.toLocal8Bit());
+        qputenv("LC_MESSAGES", lang.toLocal8Bit());
     }
     ~Language()
     {
-        qputenv("LANG", mPreviousLang.toLocal8Bit());
+        qputenv("LC_MESSAGES", mPreviousLang.toLocal8Bit());
     }
 private:
     QString mPreviousLang;


### PR DESCRIPTION
LC_MESSAGES is the first in the hierarchy. Using LANG can lead to false
positives.