### PR TITLE
Allow xdg-user-dirs in the realpath of $HOME.

### DIFF
--- a/qtxdg/xdgdirs.cpp
+++ b/qtxdg/xdgdirs.cpp
@@ -178,10 +178,12 @@ bool XdgDirs::setUserDir(XdgDirs::UserDirectory dir, const QString& value, bool 
     if (dir < XdgDirs::Desktop || dir > XdgDirs::Videos)
         return false;
 
+    const QString home = QFile::decodeName(qgetenv("HOME"));
     if (!(value.startsWith(QLatin1String("$HOME"))
                            || value.startsWith(QLatin1String("~/"))
-                           || value.startsWith(QFile::decodeName(qgetenv("HOME")))))
-        return false;
+                           || value.startsWith(home)
+                           || value.startsWith(QDir(home).canonicalPath())))
+	return false;
 
     QString folderName = userDirectoryString[dir];
 


### PR DESCRIPTION
On some systems /home is a symlink and $HOME points to the symlink.
This commit allows the xdg-user-dirs to start with the real/canonical path.

This did happen to be a problem in FreeBSD when changing xdg-user-dirs wiith lxqt-session-config  [lxqt-session-config](https://github.com/lxde/lxqt-session/blob/master/lxqt-config-session/userlocationspage.cpp#L175) returned false, because the path started with /usr and was not in $HOME..