### PR TITLE
[WIP] qiconloader: Reuse Qt implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(QTXDG_MINOR_VERSION 0)
 set(QTXDG_PATCH_VERSION 0)
 set(QTXDG_VERSION_STRING ${QTXDG_MAJOR_VERSION}.${QTXDG_MINOR_VERSION}.${QTXDG_PATCH_VERSION})
 
-set(QT_MINIMUM_VERSION "5.4.2")
+set(QT_MINIMUM_VERSION "5.5.1")
 
 include(GNUInstallDirs)             # Standard directories for installation
 include(CMakePackageConfigHelpers)

--- a/qtxdg/xdgicon.cpp
+++ b/qtxdg/xdgicon.cpp
@@ -69,25 +69,6 @@ XdgIcon::~XdgIcon()
 
 
 /************************************************
- Returns the name of the current icon theme.
- ************************************************/
-QString XdgIcon::themeName()
-{
-    return QIcon::themeName();
-}
-
-
-/************************************************
- Sets the current icon theme to name.
- ************************************************/
-void XdgIcon::setThemeName(const QString& themeName)
-{
-    QIcon::setThemeName(themeName);
-    XdgIconLoader::instance()->updateSystemTheme();
-}
-
-
-/************************************************
  Returns the QIcon corresponding to name in the current icon theme. If no such icon
  is found in the current theme fallback is return instead.
  ************************************************/

--- a/qtxdg/xdgicon.h
+++ b/qtxdg/xdgicon.h
@@ -44,8 +44,9 @@ public:
                            const QString &fallbackIcon4 = QString());
     static QIcon fromTheme(const QStringList& iconNames, const QIcon& fallback = QIcon());
 
-    static QString themeName();
-    static void setThemeName(const QString& themeName);
+    /* TODO: deprecate & remove all QIcon wrappers */
+    static QString themeName() { return QIcon::themeName(); }
+    static void setThemeName(const QString& themeName) { QIcon::setThemeName(themeName); }
 
     static QIcon defaultApplicationIcon();
     static QString defaultApplicationIconName();

--- a/xdgiconloader/xdgiconloader_p.h
+++ b/xdgiconloader/xdgiconloader_p.h
@@ -31,8 +31,8 @@
 **
 ****************************************************************************/
 
-#ifndef QICONLOADER_P_H
-#define QICONLOADER_P_H
+#ifndef XDGICONLOADER_P_H
+#define XDGICONLOADER_P_H
 
 #include <QtCore/qglobal.h>
 
@@ -52,66 +52,14 @@
 
 #include <QtGui/QIcon>
 #include <QtGui/QIconEngine>
-#include <QtGui/QPixmapCache>
 #include <private/qicon_p.h>
-#include <private/qfactoryloader_p.h>
+#include <private/qiconloader_p.h>
 #include <QtCore/QHash>
 #include <QtCore/QVector>
-#include <QtCore/QTypeInfo>
 
 //QT_BEGIN_NAMESPACE
 
 class XdgIconLoader;
-
-struct XdgIconDirInfo
-{
-    enum Type { Fixed, Scalable, Threshold };
-    XdgIconDirInfo(const QString &_path = QString()) :
-            path(_path),
-            size(0),
-            maxSize(0),
-            minSize(0),
-            threshold(0),
-            type(Threshold) {}
-    QString path;
-    short size;
-    short maxSize;
-    short minSize;
-    short threshold;
-    Type type;
-};
-
-class XdgIconLoaderEngineEntry
- {
-public:
-    virtual ~XdgIconLoaderEngineEntry() {}
-    virtual QPixmap pixmap(const QSize &size,
-                           QIcon::Mode mode,
-                           QIcon::State state) = 0;
-    QString filename;
-    XdgIconDirInfo dir;
-    static int count;
-};
-
-struct ScalableEntry : public XdgIconLoaderEngineEntry
-{
-    QPixmap pixmap(const QSize &size, QIcon::Mode mode, QIcon::State state) Q_DECL_OVERRIDE;
-    QIcon svgIcon;
-};
-
-struct PixmapEntry : public XdgIconLoaderEngineEntry
-{
-    QPixmap pixmap(const QSize &size, QIcon::Mode mode, QIcon::State state) Q_DECL_OVERRIDE;
-    QPixmap basePixmap;
-};
-
-typedef QList<XdgIconLoaderEngineEntry*> QThemeIconEntries;
-
-struct QThemeIconInfo
-{
-    QThemeIconEntries entries;
-    QString iconName;
-};
 
 //class QIconLoaderEngine : public QIconEngine
 class XDGICONLOADER_EXPORT XdgIconLoaderEngine : public QIconEngine
@@ -132,7 +80,7 @@ private:
     bool hasIcon() const;
     void ensureLoaded();
     void virtual_hook(int id, void *data);
-    XdgIconLoaderEngineEntry *entryForSize(const QSize &size);
+    QIconLoaderEngineEntry *entryForSize(const QSize &size);
     XdgIconLoaderEngine(const XdgIconLoaderEngine &other);
     QThemeIconInfo m_info;
     QString m_iconName;
@@ -143,18 +91,20 @@ private:
 
 class QIconCacheGtkReader;
 
-class QIconTheme
+// Note: We can't simply reuse the QIconTheme from Qt > 5.7 because
+// the QIconTheme constructor symbol isn't exported.
+class XdgIconTheme
 {
 public:
-    QIconTheme(const QString &name);
-    QIconTheme() : m_valid(false) {}
+    XdgIconTheme(const QString &name);
+    XdgIconTheme() : m_valid(false) {}
     QStringList parents() { return m_parents; }
-    QVector <XdgIconDirInfo> keyList() { return m_keyList; }
+    QVector <QIconDirInfo> keyList() { return m_keyList; }
     QStringList contentDirs() { return m_contentDirs; }
     bool isValid() { return m_valid; }
 private:
     QStringList m_contentDirs;
-    QVector <XdgIconDirInfo> m_keyList;
+    QVector <QIconDirInfo> m_keyList;
     QStringList m_parents;
     bool m_valid;
 public:
@@ -164,43 +114,31 @@ public:
 class XDGICONLOADER_EXPORT XdgIconLoader
 {
 public:
-    XdgIconLoader();
     QThemeIconInfo loadIcon(const QString &iconName) const;
-    uint themeKey() const { return m_themeKey; }
 
-    QString themeName() const { return m_userTheme.isEmpty() ? m_systemTheme : m_userTheme; }
-    void setThemeName(const QString &themeName);
-    QIconTheme theme() { return themeList.value(themeName()); }
-    void setThemeSearchPath(const QStringList &searchPaths);
-    QStringList themeSearchPaths() const;
-    XdgIconDirInfo dirInfo(int dirindex);
+    /* TODO: deprecate & remove all QIconLoader wrappers */
+    inline uint themeKey() const { return QIconLoader::instance()->themeKey(); }
+    inline QString themeName() const { return QIconLoader::instance()->themeName(); }
+    inline void setThemeName(const QString &themeName) { QIconLoader::instance()->setThemeName(themeName); }
+    inline void setThemeSearchPath(const QStringList &searchPaths) { QIconLoader::instance()->setThemeSearchPath(searchPaths); }
+    inline QIconDirInfo dirInfo(int dirindex) { return QIconLoader::instance()->dirInfo(dirindex); }
+    inline QStringList themeSearchPaths() const { return QIconLoader::instance()->themeSearchPaths(); }
+    inline void updateSystemTheme() { QIconLoader::instance()->updateSystemTheme(); }
+    inline void invalidateKey() { QIconLoader::instance()->invalidateKey(); }
+    inline void ensureInitialized() { QIconLoader::instance()->ensureInitialized(); }
+    inline bool hasUserTheme() const { return QIconLoader::instance()->hasUserTheme(); }
+
+    XdgIconTheme theme() { return themeList.value(QIconLoader::instance()->themeName()); }
     static XdgIconLoader *instance();
-    void updateSystemTheme();
-    void invalidateKey() { m_themeKey++; }
-    void ensureInitialized();
-    bool hasUserTheme() const { return !m_userTheme.isEmpty(); }
 
 private:
     QThemeIconInfo findIconHelper(const QString &themeName,
                                   const QString &iconName,
                                   QStringList &visited) const;
-    uint m_themeKey;
-    bool m_supportsSvg;
-    bool m_initialized;
-
-    mutable QString m_userTheme;
-    mutable QString m_systemTheme;
     mutable QStringList m_iconDirs;
-    mutable QHash <QString, QIconTheme> themeList;
+    mutable QHash <QString, XdgIconTheme> themeList;
 };
-
-
-// Note: class template specialization of 'QTypeInfo' must occur at
-//       global scope
-Q_DECLARE_TYPEINFO(XdgIconDirInfo, Q_MOVABLE_TYPE);
-
-//QT_END_NAMESPACE
 
 #endif // QT_NO_ICON
 
-#endif // QICONLOADER_P_H
+#endif // XDGICONLOADER_P_H


### PR DESCRIPTION
1. Use as much of the Qt QIconLoader implementation as possible (do not
just copy-paste all of the logic from Qt sources).
2. Do not store the currently set theme name in XdgIconLoader instance,
but reuse the underlying QIconLoader for it.

With this change there is only one place where the current theme (name,
paths, etc.) is stored => the calls XdgIcon::\*themeName and
QIcon::\*themeName are interchangable.

TODO: deprecate and/or remove the XdgIcon & XdgIconLoader wrapper
functions (which only call QIcon & QIconLoader functions).