### PR TITLE
Really return fallback icon

### DIFF
--- a/qtxdg/xdgicon.cpp
+++ b/qtxdg/xdgicon.cpp
@@ -104,7 +104,7 @@ QIcon XdgIcon::fromTheme(const QString& iconName, const QIcon& fallback)
 
     // Note the qapp check is to allow lazy loading of static icons
     // Supporting fallbacks will not work for this case.
-    if (qApp && !isAbsolute && (icon.availableSizes().isEmpty() || icon.name() != iconName))
+    if (qApp && !isAbsolute && icon.availableSizes().isEmpty())
     {
         return fallback;
     }
@@ -121,7 +121,7 @@ QIcon XdgIcon::fromTheme(const QStringList& iconNames, const QIcon& fallback)
     foreach (const QString &iconName, iconNames)
     {
         QIcon icon = fromTheme(iconName);
-        if (!icon.isNull() && icon.name() == iconName)
+        if (!icon.isNull())
             return icon;
     }
 

--- a/qtxdg/xdgicon.cpp
+++ b/qtxdg/xdgicon.cpp
@@ -104,7 +104,7 @@ QIcon XdgIcon::fromTheme(const QString& iconName, const QIcon& fallback)
 
     // Note the qapp check is to allow lazy loading of static icons
     // Supporting fallbacks will not work for this case.
-    if (qApp && !isAbsolute && icon.availableSizes().isEmpty())
+    if (qApp && !isAbsolute && (icon.availableSizes().isEmpty() || icon.name() != iconName))
     {
         return fallback;
     }
@@ -121,7 +121,7 @@ QIcon XdgIcon::fromTheme(const QStringList& iconNames, const QIcon& fallback)
     foreach (const QString &iconName, iconNames)
     {
         QIcon icon = fromTheme(iconName);
-        if (!icon.isNull())
+        if (!icon.isNull() && icon.name() == iconName)
             return icon;
     }
 

--- a/xdgiconloader/xdgiconloader.cpp
+++ b/xdgiconloader/xdgiconloader.cpp
@@ -394,12 +394,7 @@ QThemeIconInfo XdgIconLoader::findIconHelper(const QString &themeName,
             break;
         }
 
-        // If it's possible - find next fallback for the icon
-        const int indexOfDash = iconNameFallback.lastIndexOf(QLatin1Char('-'));
-        if (indexOfDash == -1)
-            break;
-
-        iconNameFallback.truncate(indexOfDash);
+        break;
     }
 
     if (info.entries.isEmpty()) {


### PR DESCRIPTION
When an icon is missing, `XdgIcon::fromTheme()` returns another icon whose name is the starting part of the missing icon name, instead of showing fallback. This patch fixes that and will be followed by another patch for lxqt-panel.