### PR TITLE
Correct hierarchy of fallbacks

### DIFF
--- a/xdgiconloader/xdgiconloader_p.h
+++ b/xdgiconloader/xdgiconloader_p.h
@@ -134,7 +134,8 @@ public:
 private:
     QThemeIconInfo findIconHelper(const QString &themeName,
                                   const QString &iconName,
-                                  QStringList &visited) const;
+                                  QStringList &visited,
+                                  bool dashFallback = false) const;
     mutable QStringList m_iconDirs;
     mutable QHash <QString, XdgIconTheme> themeList;
 };


### PR DESCRIPTION
This is my idea of a *practically* correct hierarchy of fallbacks, in contrast to what XDG specification tells us.

The icon is searched in the theme *and all of its parents*. Then, if it is not found, the search is done for the first "dash fallback" in the theme and all of its parents. And so on for the second, third,... "dash fallbacks".

Anyone has right to hate this but I use it to have acceptable fallback icons under LXQt, in the same way I have them under KDE.