### PR TITLE
Support symbolic SVG icons

### DIFF
--- a/xdgiconloader/xdgiconloader.cpp
+++ b/xdgiconloader/xdgiconloader.cpp
@@ -719,13 +719,10 @@ QPixmap PixmapEntry::pixmap(const QSize &size, QIcon::Mode mode, QIcon::State st
 
 QPixmap ScalableEntry::pixmap(const QSize &size, QIcon::Mode mode, QIcon::State state)
 {
-    if (svgIcon.isNull())
-        svgIcon = QIcon(filename);
-
-    QImage img;
     // The following lines are adapted from KDE's "kiconloader.cpp" ->
     // KIconLoaderPrivate::processSvg() and KIconLoaderPrivate::createIconImage().
     // They read the SVG color scheme of SVG icons and give images based on the icon mode.
+    QImage img;
     QScopedPointer<QImageReader> reader;
     QBuffer buffer;
     if (filename.endsWith(QLatin1String("svg"))) {
@@ -771,17 +768,17 @@ QPixmap ScalableEntry::pixmap(const QSize &size, QIcon::Mode mode, QIcon::State 
     }
 
     QPixmap px;
-    QIcon icn;
     if (!img.isNull() && px.convertFromImage(img)) {
         // Do not return the pixmap now but get the icon from it
         // for QIcon::pixmap() to handle states and modes,
         // especially the disabled mode.
-        icn = QIcon(px);
+        svgIcon = QIcon(px);
     }
-    else
-      icn = svgIcon;
 
-    return icn.pixmap(size, mode, state);
+    if (svgIcon.isNull()) // not really needed with SVG icons
+        svgIcon = QIcon(filename);
+
+    return svgIcon.pixmap(size, mode, state);
 }
 
 QPixmap XdgIconLoaderEngine::pixmap(const QSize &size, QIcon::Mode mode,

--- a/xdgiconloader/xdgiconloader.cpp
+++ b/xdgiconloader/xdgiconloader.cpp
@@ -45,6 +45,9 @@
 #include <QtCore/QDir>
 #include <QtCore/QSettings>
 #include <QtGui/QPainter>
+#include <QImageReader>
+#include <QXmlStreamReader>
+#include <QBuffer>
 
 #ifdef Q_DEAD_CODE_FROM_QT4_MAC
 #include <private/qt_cocoa_helpers_mac_p.h>
@@ -719,8 +722,66 @@ QPixmap ScalableEntry::pixmap(const QSize &size, QIcon::Mode mode, QIcon::State 
     if (svgIcon.isNull())
         svgIcon = QIcon(filename);
 
-    // Simply reuse svg icon engine
-    return svgIcon.pixmap(size, mode, state);
+    QImage img;
+    // The following lines are adapted from KDE's "kiconloader.cpp" ->
+    // KIconLoaderPrivate::processSvg() and KIconLoaderPrivate::createIconImage().
+    // They read the SVG color scheme of SVG icons and give images based on the icon mode.
+    QScopedPointer<QImageReader> reader;
+    QBuffer buffer;
+    if (filename.endsWith(QLatin1String("svg"))) {
+        QByteArray processedContents;
+        QScopedPointer<QIODevice> device;
+        device.reset(new QFile(filename));
+        if (device->open(QIODevice::ReadOnly)) {
+            const QPalette pal = qApp->palette();
+            QString styleSheet = QStringLiteral(".ColorScheme-Text{color:%1;}")
+                                 .arg(mode == QIcon::Selected
+                                      ? pal.highlightedText().color().name()
+                                      : pal.windowText().color().name());
+            QXmlStreamReader xmlReader(device.data());
+            QBuffer contentsBuffer(&processedContents);
+            contentsBuffer.open(QIODevice::WriteOnly);
+            QXmlStreamWriter writer(&contentsBuffer);
+            while (!xmlReader.atEnd()) {
+                if (xmlReader.readNext() == QXmlStreamReader::StartElement
+                    && xmlReader.qualifiedName() == QLatin1String("style")
+                    && xmlReader.attributes().value(QLatin1String("id")) == QLatin1String("current-color-scheme")) {
+                    writer.writeStartElement(QLatin1String("style"));
+                    writer.writeAttributes(xmlReader.attributes());
+                    writer.writeCharacters(styleSheet);
+                    writer.writeEndElement();
+                    while (xmlReader.tokenType() != QXmlStreamReader::EndElement)
+                        xmlReader.readNext();
+                }
+                else if (xmlReader.tokenType() != QXmlStreamReader::Invalid)
+                    writer.writeCurrentToken(xmlReader);
+            }
+            contentsBuffer.close();
+        }
+        buffer.setData(processedContents);
+        reader.reset(new QImageReader(&buffer));
+    }
+    else 
+        reader.reset(new QImageReader(filename));
+    if (reader->canRead()) {
+        int width = size.width();
+        if (width != 0)
+            reader->setScaledSize(QSize(width, width));
+        img = reader->read();
+    }
+
+    QPixmap px;
+    QIcon icn;
+    if (!img.isNull() && px.convertFromImage(img)) {
+        // Do not return the pixmap now but get the icon from it
+        // for QIcon::pixmap() to handle states and modes,
+        // especially the disabled mode.
+        icn = QIcon(px);
+    }
+    else
+      icn = svgIcon;
+
+    return icn.pixmap(size, mode, state);
 }
 
 QPixmap XdgIconLoaderEngine::pixmap(const QSize &size, QIcon::Mode mode,


### PR DESCRIPTION
Fixes https://github.com/lxde/lxqt/issues/1181.

That means changing their colors so that they always have a high contrast with their backgrounds. Symbolic icons should have SVG stylesheets (as the Breeze icons do) and the style engine should support them (as the Breeze and Kvantum styles do).

The code is stolen from KDE's `kiconloader.cpp` (see the comments).

Currently Panel and those LXQt apps that use stylesheets will show the wrong icon color if their stylesheets have a high contrast with the active Qt style. This issue should be fixed in their codes before this PR is merged.