### PR TITLE
xdgiconloader: Puts the hicolor at the end of the theme hierarchy

### DIFF
--- a/xdgiconloader/xdgiconloader.cpp
+++ b/xdgiconloader/xdgiconloader.cpp
@@ -445,73 +445,6 @@ QThemeIconInfo XdgIconLoader::findIconHelper(const QString &themeName,
         }
     }
 
-    if (info.entries.isEmpty()) {
-       // Search for unthemed icons in main dir of search paths
-       QStringList themeSearchPaths = QIcon::themeSearchPaths();
-        foreach (QString contentDir, themeSearchPaths)  {
-            QDir currentDir(contentDir);
-
-            if (currentDir.exists(iconName + pngext)) {
-                PixmapEntry *iconEntry = new PixmapEntry;
-                iconEntry->filename = currentDir.filePath(iconName + pngext);
-                // Notice we ensure that pixmap entries always come before
-                // scalable to preserve search order afterwards
-                info.entries.prepend(iconEntry);
-            } else if (gSupportsSvg &&
-                currentDir.exists(iconName + svgext)) {
-                ScalableEntry *iconEntry = (followColorScheme() && theme.followsColorScheme()) ? new ScalableFollowsColorEntry : new ScalableEntry;
-                iconEntry->filename = currentDir.filePath(iconName + svgext);
-                info.entries.append(iconEntry);
-            } else if (currentDir.exists(iconName + xpmext)) {
-                PixmapEntry *iconEntry = new PixmapEntry;
-                iconEntry->filename = currentDir.filePath(iconName + xpmext);
-                // Notice we ensure that pixmap entries always come before
-                // scalable to preserve search order afterwards
-                info.entries.append(iconEntry);
-            }
-        }
-    }
-
-
-    /*********************************************************************
-    Author: Kaitlin Rupert <kaitlin.rupert@intel.com>
-    Date: Aug 12, 2010
-    Description: Make it so that the QIcon loader honors /usr/share/pixmaps
-                 directory.  This is a valid directory per the Freedesktop.org
-                 icon theme specification.
-    Bug: https://bugreports.qt.nokia.com/browse/QTBUG-12874
-     *********************************************************************/
-#ifdef Q_OS_LINUX
-    /* Freedesktop standard says to look in /usr/share/pixmaps last */
-    if (info.entries.isEmpty()) {
-        const QString pixmaps(QLatin1String("/usr/share/pixmaps"));
-
-        const QDir currentDir(pixmaps);
-        const QIconDirInfo dirInfo(pixmaps);
-        if (currentDir.exists(iconName + pngext)) {
-            PixmapEntry *iconEntry = new PixmapEntry;
-            iconEntry->dir = dirInfo;
-            iconEntry->filename = currentDir.filePath(iconName + pngext);
-            // Notice we ensure that pixmap entries always come before
-            // scalable to preserve search order afterwards
-            info.entries.prepend(iconEntry);
-        } else if (gSupportsSvg &&
-                   currentDir.exists(iconName + svgext)) {
-            ScalableEntry *iconEntry = (followColorScheme() && theme.followsColorScheme()) ? new ScalableFollowsColorEntry : new ScalableEntry;
-            iconEntry->dir = dirInfo;
-            iconEntry->filename = currentDir.filePath(iconName + svgext);
-            info.entries.append(iconEntry);
-        } else if (currentDir.exists(iconName + xpmext)) {
-            PixmapEntry *iconEntry = new PixmapEntry;
-            iconEntry->dir = dirInfo;
-            iconEntry->filename = currentDir.filePath(iconName + xpmext);
-            // Notice we ensure that pixmap entries always come before
-            // scalable to preserve search order afterwards
-            info.entries.append(iconEntry);
-        }
-    }
-#endif
-
     if (dashFallback && info.entries.isEmpty()) {
         // If it's possible - find next fallback for the icon
         const int indexOfDash = iconNameFallback.lastIndexOf(QLatin1Char('-'));
@@ -525,16 +458,67 @@ QThemeIconInfo XdgIconLoader::findIconHelper(const QString &themeName,
     return info;
 }
 
+QThemeIconInfo XdgIconLoader::unthemedFallback(const QString &iconName, const QStringList &searchPaths) const
+{
+    QThemeIconInfo info;
+
+    const QString svgext(QLatin1String(".svg"));
+    const QString pngext(QLatin1String(".png"));
+    const QString xpmext(QLatin1String(".xpm"));
+
+    for (const auto &contentDir : searchPaths)  {
+        QDir currentDir(contentDir);
+
+        if (currentDir.exists(iconName + pngext)) {
+            PixmapEntry *iconEntry = new PixmapEntry;
+            iconEntry->filename = currentDir.filePath(iconName + pngext);
+            // Notice we ensure that pixmap entries always come before
+            // scalable to preserve search order afterwards
+            info.entries.prepend(iconEntry);
+        } else if (gSupportsSvg &&
+            currentDir.exists(iconName + svgext)) {
+            ScalableEntry *iconEntry = new ScalableEntry;
+            iconEntry->filename = currentDir.filePath(iconName + svgext);
+            info.entries.append(iconEntry);
+        } else if (currentDir.exists(iconName + xpmext)) {
+            PixmapEntry *iconEntry = new PixmapEntry;
+            iconEntry->filename = currentDir.filePath(iconName + xpmext);
+            // Notice we ensure that pixmap entries always come before
+            // scalable to preserve search order afterwards
+            info.entries.append(iconEntry);
+        }
+    }
+    return info;
+}
+
 QThemeIconInfo XdgIconLoader::loadIcon(const QString &name) const
 {
     const QString theme_name = QIconLoader::instance()->themeName();
     if (!theme_name.isEmpty()) {
         QStringList visited;
         auto info = findIconHelper(theme_name, name, visited, true);
-        if (info.entries.isEmpty())
-           return findIconHelper(QLatin1String("hicolor"), name, visited, true);
-        else
+        if (info.entries.isEmpty()) {
+            const auto hicolorInfo = findIconHelper(QLatin1String("hicolor"), name, visited, true);
+            if (hicolorInfo.entries.isEmpty()) {
+                const auto unthemedInfo = unthemedFallback(name, QIcon::themeSearchPaths());
+                if (unthemedInfo.entries.isEmpty()) {
+                    /* Freedesktop standard says to look in /usr/share/pixmaps last */
+                    const QStringList pixmapPath = (QStringList() << QString::fromLatin1("/usr/share/pixmaps"));
+                    const auto pixmapInfo = unthemedFallback(name, pixmapPath);
+                    if (pixmapInfo.entries.isEmpty()) {
+                        return QThemeIconInfo();
+                    } else {
+                        return pixmapInfo;
+                    }
+                } else {
+                    return unthemedInfo;
+                }
+            } else {
+                return hicolorInfo;
+            }
+        } else {
             return info;
+        }
     }
 
     return QThemeIconInfo();

--- a/xdgiconloader/xdgiconloader.cpp
+++ b/xdgiconloader/xdgiconloader.cpp
@@ -64,10 +64,13 @@ static QString fallbackTheme()
 {
     if (const QPlatformTheme *theme = QGuiApplicationPrivate::platformTheme()) {
         const QVariant themeHint = theme->themeHint(QPlatformTheme::SystemIconFallbackThemeName);
-        if (themeHint.isValid())
-            return themeHint.toString();
+        if (themeHint.isValid()) {
+            const QString theme = themeHint.toString();
+            if (theme != QLatin1String("hicolor"))
+                return theme;
+        }
     }
-    return QLatin1String("hicolor");
+    return QString();
 }
 
 #ifdef QT_NO_LIBRARY
@@ -293,6 +296,7 @@ XdgIconTheme::XdgIconTheme(const QString &themeName)
         m_parents = indexReader.value(
                 QLatin1String("Icon Theme/Inherits")).toStringList();
         m_parents.removeAll(QString());
+        m_parents.removeAll(QLatin1String("hicolor"));
 
         // Ensure a default platform fallback for all themes
         if (m_parents.isEmpty()) {
@@ -300,10 +304,6 @@ XdgIconTheme::XdgIconTheme(const QString &themeName)
             if (!fallback.isEmpty())
                 m_parents.append(fallback);
         }
-
-        // Ensure that all themes fall back to hicolor
-        if (!m_parents.contains(QLatin1String("hicolor")))
-            m_parents.append(QLatin1String("hicolor"));
     }
 #endif //QT_NO_SETTINGS
 }
@@ -344,8 +344,11 @@ QThemeIconInfo XdgIconLoader::findIconHelper(const QString &themeName,
     XdgIconTheme &theme = themeList[themeName];
     if (!theme.isValid()) {
         theme = XdgIconTheme(themeName);
-        if (!theme.isValid())
-            theme = XdgIconTheme(fallbackTheme());
+        if (!theme.isValid()) {
+            const QString fallback = fallbackTheme();
+            if (!fallback.isEmpty())
+                theme = XdgIconTheme(fallback);
+        }
     }
 
     const QStringList contentDirs = theme.contentDirs();
@@ -527,7 +530,11 @@ QThemeIconInfo XdgIconLoader::loadIcon(const QString &name) const
     const QString theme_name = QIconLoader::instance()->themeName();
     if (!theme_name.isEmpty()) {
         QStringList visited;
-        return findIconHelper(theme_name, name, visited, true);
+        auto info = findIconHelper(theme_name, name, visited, true);
+        if (info.entries.isEmpty())
+           return findIconHelper(QLatin1String("hicolor"), name, visited, true);
+        else
+            return info;
     }
 
     return QThemeIconInfo();

--- a/xdgiconloader/xdgiconloader_p.h
+++ b/xdgiconloader/xdgiconloader_p.h
@@ -150,6 +150,7 @@ private:
                                   const QString &iconName,
                                   QStringList &visited,
                                   bool dashFallback = false) const;
+    QThemeIconInfo unthemedFallback(const QString &iconName, const QStringList &searchPaths) const;
     mutable QHash <QString, XdgIconTheme> themeList;
     bool m_followColorScheme = true;
 };


### PR DESCRIPTION
The hicolor theme is the ultimate resort. It should be allowed only at the
end of the fallback hierarchy. We are allowing the hicolor theme to be in
the middle of the theme hierarchy. Schematically:
	X -> hicolor -> Y -> Z -> hicolor
If an icon exists in the hicolor and Y theme the hicolor one, is wrongly
used.

This commit does four things:
    * Stops adding the hicolor theme to each theme as a fallback.
    * Stops adding the hicolor as a parent theme, even if added by the
index.theme Inherits key. The oxygen theme does it.
    * Stops return the hicolor theme in the fallbackTheme().
    * Adds the hicolor theme to the end of the fallback hierarchy list.