### PR TITLE
xdgiconloader: Puts the hicolor at the end of the theme hierarchy

### DIFF
--- a/xdgiconloader/xdgiconloader_p.h
+++ b/xdgiconloader/xdgiconloader_p.h
@@ -136,6 +136,7 @@ private:
                                   const QString &iconName,
                                   QStringList &visited,
                                   bool dashFallback = false) const;
+    QThemeIconInfo unthemedFallback(const QString &iconName) const;
     QThemeIconInfo pixmapFallback(const QString &iconName) const;
     mutable QStringList m_iconDirs;
     mutable QHash <QString, XdgIconTheme> themeList;

--- a/xdgiconloader/xdgiconloader_p.h
+++ b/xdgiconloader/xdgiconloader_p.h
@@ -136,6 +136,7 @@ private:
                                   const QString &iconName,
                                   QStringList &visited,
                                   bool dashFallback = false) const;
+    QThemeIconInfo pixmapFallback(const QString &iconName) const;
     mutable QStringList m_iconDirs;
     mutable QHash <QString, XdgIconTheme> themeList;
 };


### PR DESCRIPTION
The hicolor theme is the ultimate resort. It should be allowed only at the
end of the fallback hierarchy. We are allowing the hicolor theme to be in
the middle of the theme hierarchy. Schematically:
        X -> hicolor -> Y -> Z -> hicolor
If an icon exists in the hicolor and Y theme the hicolor one, is wrongly
used.

This commit does four things:
    * Stops adding the hicolor theme to each theme as a fallback.
    * Stops adding the hicolor as a parent theme, even if added by the
index.theme Inherits key. The oxygen theme does it.
    * Stops return the hicolor theme in the fallbackTheme().
    * Adds the hicolor theme to the end of the fallback hierarchy list.