### PR TITLE
xdgiconloader: Fix XdgIconLoaderEngine::actualSize()

### DIFF
--- a/xdgiconloader/xdgiconloader.cpp
+++ b/xdgiconloader/xdgiconloader.cpp
@@ -672,7 +672,7 @@ QSize XdgIconLoaderEngine::actualSize(const QSize &size, QIcon::Mode mode,
             return QSize(result, result);
         }
     }
-    return QIconEngine::actualSize(size, mode, state);
+    return {0, 0};
 }
 
 QPixmap PixmapEntry::pixmap(const QSize &size, QIcon::Mode mode, QIcon::State state)


### PR DESCRIPTION
Return an empty size if no suitable entry found to avoid mismatch
with the returned `pixmap()`'s size (the `QIconEngine::actualSize()` returns
the originally requested size).

closes lxde/lxqt#1282