### PR TITLE
Avoid Qt special keywords collision

### DIFF
--- a/qtxdg/CMakeLists.txt
+++ b/qtxdg/CMakeLists.txt
@@ -82,6 +82,7 @@ target_compile_definitions(${QTXDGX_LIBRARY_NAME}
     PRIVATE
         "QTXDG_COMPILATION=\"1\""
         "QTXDG_VERSION=\"${QTXDG_VERSION_STRING}\""
+        "QT_NO_KEYWORDS"
 )
 
 target_include_directories(${QTXDGX_LIBRARY_NAME}

--- a/qtxdg/xdgaction.h
+++ b/qtxdg/xdgaction.h
@@ -71,7 +71,7 @@ public:
 
     const XdgDesktopFile& desktopFile() const { return mDesktopFile; }
 
-private slots:
+private Q_SLOTS:
     void runConmmand() const;
     void updateIcon();
 

--- a/qtxdg/xdgautostart.cpp
+++ b/qtxdg/xdgautostart.cpp
@@ -57,14 +57,14 @@ XdgDesktopFileList XdgAutoStart::desktopFileList(QStringList dirs, bool excludeH
 
     QSet<QString> processed;
     XdgDesktopFileList ret;
-    foreach (const QString &dirName, dirs)
+    Q_FOREACH (const QString &dirName, dirs)
     {
         QDir dir(dirName);
         if (!dir.exists())
             continue;
 
         const QFileInfoList files = dir.entryInfoList(QStringList(QLatin1String("*.desktop")), QDir::Files | QDir::Readable);
-        foreach (const QFileInfo &fi, files)
+        Q_FOREACH (const QFileInfo &fi, files)
         {
             if (processed.contains(fi.fileName()))
                 continue;

--- a/qtxdg/xdgdesktopfile.cpp
+++ b/qtxdg/xdgdesktopfile.cpp
@@ -409,9 +409,9 @@ bool XdgDesktopFileData::startApplicationDetached(const XdgDesktopFile *q, const
     }
 
     bool nonDetach = false;
-    foreach(const QString &s, nonDetachExecs)
+    Q_FOREACH(const QString &s, nonDetachExecs)
     {
-        foreach(const QString &a, args)
+        Q_FOREACH(const QString &a, args)
         {
             if (a.contains(s))
             {
@@ -953,7 +953,7 @@ QString expandEnvVariables(const QString str)
 QStringList expandEnvVariables(const QStringList strs)
 {
     QStringList res;
-    foreach(const QString &s, strs)
+    Q_FOREACH(const QString &s, strs)
         res << expandEnvVariables(s);
 
     return res;
@@ -971,7 +971,7 @@ QStringList XdgDesktopFile::expandExecString(const QStringList& urls) const
     unEscapeExec(execStr);
     QStringList tokens = parseCombinedArgString(execStr);
 
-    foreach (QString token, tokens)
+    Q_FOREACH (QString token, tokens)
     {
         // The parseCombinedArgString() splits the string by the space symbols,
         // we temporarily replaced them on the special characters.
@@ -1016,7 +1016,7 @@ QStringList XdgDesktopFile::expandExecString(const QStringList& urls) const
         // program. Local files may either be passed as file: URLs or as file path.
         if (token == QLatin1String("%U"))
         {
-            foreach (const QString &s, urls)
+            Q_FOREACH (const QString &s, urls)
             {
                 QUrl url(expandEnvVariables(s));
                 result << ((!url.toLocalFile().isEmpty()) ? url.toLocalFile() : QString::fromUtf8(url.toEncoded()));
@@ -1081,7 +1081,7 @@ bool checkTryExec(const QString& progName)
 
     QStringList dirs = QFile::decodeName(qgetenv("PATH")).split(QLatin1Char(':'));
 
-    foreach (const QString &dir, dirs)
+    Q_FOREACH (const QString &dir, dirs)
     {
         if (QFileInfo(QDir(dir), progName).isExecutable())
             return true;
@@ -1103,7 +1103,7 @@ QString XdgDesktopFile::id(const QString &fileName, bool checkFileExists)
     QString id = f.absoluteFilePath();
     const QStringList dataDirs = XdgDirs::dataDirs();
 
-    foreach(const QString &d, dataDirs) {
+    Q_FOREACH(const QString &d, dataDirs) {
         if (id.startsWith(d)) {
             // remove only the first occurence
             id.replace(id.indexOf(d), d.size(), QString());
@@ -1211,7 +1211,7 @@ bool XdgDesktopFile::isSuitable(bool excludeHidden, const QString &environment) 
 
 QString expandDynamicUrl(QString url)
 {
-    foreach(const QString &line, QProcess::systemEnvironment())
+    Q_FOREACH(const QString &line, QProcess::systemEnvironment())
     {
         QString name = line.section(QLatin1Char('='), 0, 0);
         QString val =  line.section(QLatin1Char('='), 1);
@@ -1253,7 +1253,7 @@ QString findDesktopFile(const QString& dirName, const QString& desktopName)
 
     // Working recursively ............
     QFileInfoList dirs = dir.entryInfoList(QStringList(), QDir::Dirs | QDir::NoDotAndDotDot);
-    foreach (const QFileInfo &d, dirs)
+    Q_FOREACH (const QFileInfo &d, dirs)
     {
         QString cn = d.canonicalFilePath();
         if (dirName != cn)
@@ -1273,7 +1273,7 @@ QString findDesktopFile(const QString& desktopName)
     QStringList dataDirs = XdgDirs::dataDirs();
     dataDirs.prepend(XdgDirs::dataHome(false));
 
-    foreach (const QString &dirName, dataDirs)
+    Q_FOREACH (const QString &dirName, dataDirs)
     {
         QString f = findDesktopFile(dirName + QLatin1String("/applications"), desktopName);
         if (!f.isEmpty())
@@ -1462,7 +1462,7 @@ void XdgDesktopFileCache::initialize(const QString& dirName)
 
     // Working recursively ............
     QFileInfoList files = dir.entryInfoList(QStringList(), QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot);
-    foreach (const QFileInfo &f, files)
+    Q_FOREACH (const QFileInfo &f, files)
     {
         if (f.isDir())
         {
@@ -1482,7 +1482,7 @@ void XdgDesktopFileCache::initialize(const QString& dirName)
 
         QStringList mimes = df->value(mimeTypeKey).toString().split(QLatin1Char(';'), QString::SkipEmptyParts);
 
-        foreach (const QString &mime, mimes)
+        Q_FOREACH (const QString &mime, mimes)
         {
             int pref = df->value(initialPreferenceKey, 0).toInt();
             // We move the desktopFile forward in the list for this mime, so that
@@ -1523,7 +1523,7 @@ void loadMimeCacheDir(const QString& dirName, QHash<QString, QList<XdgDesktopFil
 
     // Working recursively ............
     const QFileInfoList files = dir.entryInfoList(QStringList(), QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot);
-    foreach (const QFileInfo &f, files)
+    Q_FOREACH (const QFileInfo &f, files)
     {
         if (f.isDir())
         {
@@ -1538,7 +1538,7 @@ void loadMimeCacheDir(const QString& dirName, QHash<QString, QList<XdgDesktopFil
 
         const QStringList mimes = df->value(mimeTypeKey).toString().split(QLatin1Char(';'), QString::SkipEmptyParts);
 
-        foreach (const QString &mime, mimes)
+        Q_FOREACH (const QString &mime, mimes)
         {
             int pref = df->value(initialPreferenceKey, 0).toInt();
             // We move the desktopFile forward in the list for this mime, so that
@@ -1582,7 +1582,7 @@ void XdgDesktopFileCache::initialize()
     QStringList dataDirs = XdgDirs::dataDirs();
     dataDirs.prepend(XdgDirs::dataHome(false));
 
-    foreach (const QString &dirname, dataDirs)
+    Q_FOREACH (const QString &dirname, dataDirs)
     {
         initialize(dirname + QLatin1String("/applications"));
 //        loadMimeCacheDir(dirname + "/applications", m_defaultAppsCache);
@@ -1593,7 +1593,7 @@ QList<XdgDesktopFile*> XdgDesktopFileCache::getAppsOfCategory(const QString& cat
 {
     QList<XdgDesktopFile*> list;
     const QString _category = category.toUpper();
-    foreach (XdgDesktopFile *desktopFile, instance().m_fileCache)
+    Q_FOREACH (XdgDesktopFile *desktopFile, instance().m_fileCache)
     {
         QStringList categories = desktopFile->value(categoriesKey).toString().toUpper().split(QLatin1Char(';'));
         if (!categories.isEmpty() && (categories.contains(_category) || categories.contains(QLatin1String("X-") + _category)))
@@ -1614,7 +1614,7 @@ XdgDesktopFile* XdgDesktopFileCache::getDefaultApp(const QString& mimetype)
     // /usr/share/applications/mimeapps.list (in that order) for a default.
     QStringList dataDirs = XdgDirs::dataDirs();
     dataDirs.prepend(XdgDirs::dataHome(false));
-    foreach(const QString &dataDir, dataDirs)
+    Q_FOREACH(const QString &dataDir, dataDirs)
     {
         QString defaultsListPath = dataDir + QLatin1String("/applications/mimeapps.list");
         if (QFileInfo::exists(defaultsListPath))
@@ -1628,7 +1628,7 @@ XdgDesktopFile* XdgDesktopFileCache::getDefaultApp(const QString& mimetype)
                 QVariant value = defaults.value(mimetype);
                 if (value.canConvert<QStringList>()) // A single string can also convert to a stringlist
                 {
-                    foreach (const QString &desktopFileName, value.toStringList())
+                    Q_FOREACH (const QString &desktopFileName, value.toStringList())
                     {
                         XdgDesktopFile* desktopFile = XdgDesktopFileCache::getFile(desktopFileName);
                         if (desktopFile)

--- a/qtxdg/xdgdirs.cpp
+++ b/qtxdg/xdgdirs.cpp
@@ -336,7 +336,7 @@ QStringList XdgDirs::autostartDirs(const QString &postfix)
 {
     QStringList dirs;
     const QStringList s = configDirs();
-    foreach(const QString &dir, s)
+    Q_FOREACH(const QString &dir, s)
         dirs << QString::fromLatin1("%1/autostart").arg(dir) + postfix;
 
     return dirs;

--- a/qtxdg/xdgicon.cpp
+++ b/qtxdg/xdgicon.cpp
@@ -118,7 +118,7 @@ QIcon XdgIcon::fromTheme(const QString& iconName, const QIcon& fallback)
  ************************************************/
 QIcon XdgIcon::fromTheme(const QStringList& iconNames, const QIcon& fallback)
 {
-    foreach (const QString &iconName, iconNames)
+    Q_FOREACH (const QString &iconName, iconNames)
     {
         QIcon icon = fromTheme(iconName);
         if (!icon.isNull())

--- a/qtxdg/xdgmenu.cpp
+++ b/qtxdg/xdgmenu.cpp
@@ -412,7 +412,7 @@ QDomElement XdgMenu::findMenu(QDomElement& baseElement, const QString& path, boo
 
     const QStringList names = path.split(QLatin1Char('/'), QString::SkipEmptyParts);
     QDomElement el = baseElement;
-    foreach (const QString &name, names)
+    Q_FOREACH (const QString &name, names)
     {
         QDomElement p = el;
         el = d->mXml.createElement(QLatin1String("Menu"));
@@ -537,12 +537,12 @@ void XdgMenuPrivate::processDirectoryEntries(QDomElement& element, const QString
     dirs << parentDirs;
 
     bool found = false;
-    foreach(const QString &file, files){
+    Q_FOREACH(const QString &file, files){
         if (file.startsWith(QLatin1Char('/')))
             found = loadDirectoryFile(file, element);
         else
         {
-            foreach (const QString &dir, dirs)
+            Q_FOREACH (const QString &dir, dirs)
             {
                 found = loadDirectoryFile(dir + QLatin1Char('/') + file, element);
                 if (found) break;
@@ -651,7 +651,7 @@ QString XdgMenu::getMenuFileName(const QString& baseName)
     const QStringList configDirs = XdgDirs::configDirs();
     QString menuPrefix = QString::fromLocal8Bit(qgetenv("XDG_MENU_PREFIX"));
 
-    foreach(const QString &configDir, configDirs)
+    Q_FOREACH(const QString &configDir, configDirs)
     {
         QFileInfo file(QString::fromLatin1("%1/menus/%2%3").arg(configDir, menuPrefix, baseName));
         if (file.exists())
@@ -669,9 +669,9 @@ QString XdgMenu::getMenuFileName(const QString& baseName)
     wellKnownFiles << QLatin1String("gnome-applications.menu");
     wellKnownFiles << QLatin1String("lxde-applications.menu");
 
-    foreach(const QString &configDir, configDirs)
+    Q_FOREACH(const QString &configDir, configDirs)
     {
-        foreach (const QString &f, wellKnownFiles)
+        Q_FOREACH (const QString &f, wellKnownFiles)
         {
             QFileInfo file(QString::fromLatin1("%1/menus/%2").arg(configDir, f));
             if (file.exists())
@@ -714,7 +714,7 @@ void XdgMenuPrivate::rebuild()
     if (prevHash != mHash)
     {
         mOutDated = true;
-        emit changed();
+        Q_EMIT changed();
     }
 }
 

--- a/qtxdg/xdgmenu.h
+++ b/qtxdg/xdgmenu.h
@@ -112,7 +112,7 @@ public:
 
     bool isOutDated() const;
 
-signals:
+Q_SIGNALS:
     void changed();
 
 protected:

--- a/qtxdg/xdgmenu_p.h
+++ b/qtxdg/xdgmenu_p.h
@@ -73,10 +73,10 @@ public:
     QFileSystemWatcher mWatcher;
     bool mOutDated;
 
-public slots:
+public Q_SLOTS:
     void rebuild();
 
-signals:
+Q_SIGNALS:
     void changed();
 
 

--- a/qtxdg/xdgmenuapplinkprocessor.cpp
+++ b/qtxdg/xdgmenuapplinkprocessor.cpp
@@ -90,7 +90,7 @@ void XdgMenuApplinkProcessor::step1()
     }
 
     // Process childs menus ...............................
-    foreach (XdgMenuApplinkProcessor* child, mChilds)
+    Q_FOREACH (XdgMenuApplinkProcessor* child, mChilds)
         child->step1();
 }
 
@@ -100,7 +100,7 @@ void XdgMenuApplinkProcessor::step2()
     // Create AppLinks elements ...........................
     QDomDocument doc = mElement.ownerDocument();
 
-    foreach (XdgMenuAppFileInfo* fileInfo, mSelected)
+    Q_FOREACH (XdgMenuAppFileInfo* fileInfo, mSelected)
     {
         if (mOnlyUnallocated && fileInfo->allocated())
             continue;
@@ -141,7 +141,7 @@ void XdgMenuApplinkProcessor::step2()
 
 
     // Process childs menus ...............................
-    foreach (XdgMenuApplinkProcessor* child, mChilds)
+    Q_FOREACH (XdgMenuApplinkProcessor* child, mChilds)
         child->step2();
 }
 
@@ -189,7 +189,7 @@ void XdgMenuApplinkProcessor::findDesktopFiles(const QString& dirName, const QSt
     mMenu->addWatchPath(dir.absolutePath());
     const QFileInfoList files = dir.entryInfoList(QStringList(QLatin1String("*.desktop")), QDir::Files);
 
-    foreach (const QFileInfo &file, files)
+    Q_FOREACH (const QFileInfo &file, files)
     {
         XdgDesktopFile* f = XdgDesktopFileCache::getFile(file.canonicalFilePath());
         if (f)
@@ -199,7 +199,7 @@ void XdgMenuApplinkProcessor::findDesktopFiles(const QString& dirName, const QSt
 
     // Working recursively ............
     const QFileInfoList dirs = dir.entryInfoList(QStringList(), QDir::Dirs | QDir::NoDotAndDotDot);
-    foreach (const QFileInfo &d, dirs)
+    Q_FOREACH (const QFileInfo &d, dirs)
     {
         QString dn = d.canonicalFilePath();
         if (dn != dirName)
@@ -242,7 +242,7 @@ bool XdgMenuApplinkProcessor::checkTryExec(const QString& progName)
 
     const QStringList dirs = QFile::decodeName(qgetenv("PATH")).split(QLatin1Char(':'));
 
-    foreach (const QString &dir, dirs)
+    Q_FOREACH (const QString &dir, dirs)
     {
         if (QFileInfo(QDir(dir), progName).isExecutable())
             return true;

--- a/qtxdg/xdgmenureader.cpp
+++ b/qtxdg/xdgmenureader.cpp
@@ -215,7 +215,7 @@ void XdgMenuReader::processMergeFileTag(QDomElement& element, QStringList* merge
         QString relativeName;
         QStringList configDirs = XdgDirs::configDirs();
 
-        foreach (const QString &configDir, configDirs)
+        Q_FOREACH (const QString &configDir, configDirs)
         {
             if (mFileName.startsWith(configDir))
             {
@@ -236,7 +236,7 @@ void XdgMenuReader::processMergeFileTag(QDomElement& element, QStringList* merge
         if (relativeName.isEmpty())
             return;
 
-        foreach (const QString &configDir, configDirs)
+        Q_FOREACH (const QString &configDir, configDirs)
         {
             if (QFileInfo::exists(configDir + relativeName))
             {
@@ -295,7 +295,7 @@ void XdgMenuReader::processDefaultMergeDirsTag(QDomElement& element, QStringList
     QStringList dirs = XdgDirs::configDirs();
     dirs << XdgDirs::configHome();
 
-    foreach (const QString &dir, dirs)
+    Q_FOREACH (const QString &dir, dirs)
     {
         mergeDir(QString::fromLatin1("%1/menus/%2-merged").arg(dir, menuBaseName), element, mergedFiles);
     }
@@ -329,7 +329,7 @@ void XdgMenuReader::processDefaultAppDirsTag(QDomElement& element)
     QStringList dirs = XdgDirs::dataDirs();
     dirs.prepend(XdgDirs::dataHome(false));
 
-    foreach (const QString &dir, dirs)
+    Q_FOREACH (const QString &dir, dirs)
     {
         //qDebug() << "Add AppDir: " << dir + "/applications/";
         addDirTag(element, QLatin1String("AppDir"), dir + QLatin1String("/applications/"));
@@ -360,7 +360,7 @@ void XdgMenuReader::processDefaultDirectoryDirsTag(QDomElement& element)
     QStringList dirs = XdgDirs::dataDirs();
     dirs.prepend(XdgDirs::dataHome(false));
 
-    foreach (const QString &dir, dirs)
+    Q_FOREACH (const QString &dir, dirs)
         addDirTag(element, QLatin1String("DirectoryDir"), dir + QLatin1String("/desktop-directories/"));
 }
 
@@ -431,7 +431,7 @@ void XdgMenuReader::mergeDir(const QString& dirName, QDomElement& element, QStri
         QDir dir = QDir(dirInfo.canonicalFilePath());
         const QFileInfoList files = dir.entryInfoList(QStringList() << QLatin1String("*.menu"), QDir::Files | QDir::Readable);
 
-        foreach (const QFileInfo &file, files)
+        Q_FOREACH (const QFileInfo &file, files)
             mergeFile(file.canonicalFilePath(), element, mergedFiles);
     }
 }

--- a/qtxdg/xdgmenureader.h
+++ b/qtxdg/xdgmenureader.h
@@ -47,9 +47,9 @@ public:
     QString errorString() const { return mErrorStr; }
     QDomDocument& xml() { return mXml; }
 
-signals:
+Q_SIGNALS:
 
-public slots:
+public Q_SLOTS:
 
 protected:
     void processMergeTags(QDomElement& element);

--- a/qtxdg/xdgmimetype.cpp
+++ b/qtxdg/xdgmimetype.cpp
@@ -96,7 +96,7 @@ QString XdgMimeType::iconName() const
         names.append(QMimeType::iconName());
         names.append(QMimeType::genericIconName());
 
-        foreach (const QString &s, names) {
+        Q_FOREACH (const QString &s, names) {
             if (!XdgIcon::fromTheme(s).isNull()) {
                 dx->iconName = s;
                 break;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,10 @@ remove_definitions(
     -DQT_NO_CAST_FROM_ASCII
 )
 
+add_definitions(
+    -DQT_NO_KEYWORDS
+)
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 macro(qtxdg_add_test)

--- a/test/qtxdg_test.cpp
+++ b/test/qtxdg_test.cpp
@@ -47,15 +47,15 @@ void QtXdgTest::testDefaultApp()
 {
     QStringList mimedirs = XdgDirs::dataDirs();
     mimedirs.prepend(XdgDirs::dataHome(false));
-    foreach (QString mimedir, mimedirs)
+    Q_FOREACH (QString mimedir, mimedirs)
     {
         QDir dir(mimedir + "/mime");
         qDebug() << dir.path();
         QStringList filters = (QStringList() << "*.xml");
-        foreach(QFileInfo mediaDir, dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot))
+        Q_FOREACH(QFileInfo mediaDir, dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot))
         {
             qDebug() << "    " << mediaDir.fileName();
-            foreach (QString mimeXmlFileName, QDir(mediaDir.absoluteFilePath()).entryList(filters, QDir::Files))
+            Q_FOREACH (QString mimeXmlFileName, QDir(mediaDir.absoluteFilePath()).entryList(filters, QDir::Files))
             {
                 QString mimetype = mediaDir.fileName() + "/" + mimeXmlFileName.left(mimeXmlFileName.length() - 4);
                 QString xdg_utils_default = xdgUtilDefaultApp(mimetype);

--- a/test/qtxdg_test.h
+++ b/test/qtxdg_test.h
@@ -39,7 +39,7 @@ class QtXdgTest : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testCustomFormat();
 
 private:

--- a/test/tst_xdgdesktopfile.h
+++ b/test/tst_xdgdesktopfile.h
@@ -25,7 +25,7 @@
 
 class tst_xdgdesktopfile : public QObject {
     Q_OBJECT
-private slots:
+private Q_SLOTS:
 
     void testRead();
     void testReadLocalized();

--- a/test/tst_xdgdirs.cpp
+++ b/test/tst_xdgdirs.cpp
@@ -36,7 +36,7 @@ class tst_xdgdirs : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void initTestCase();
     void cleanupTestCase();
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -25,11 +25,15 @@ target_include_directories(qtxdg-iconfinder
 )
 
 target_compile_definitions(qtxdg-desktop-file-start
-    PRIVATE "-DQTXDG_VERSION=\"${QTXDG_VERSION_STRING}\""
+    PRIVATE
+        "-DQTXDG_VERSION=\"${QTXDG_VERSION_STRING}\""
+        "QT_NO_KEYWORDS"
 )
 
 target_compile_definitions(qtxdg-iconfinder
-    PRIVATE "-DQTXDG_VERSION=\"${QTXDG_VERSION_STRING}\""
+    PRIVATE
+        "-DQTXDG_VERSION=\"${QTXDG_VERSION_STRING}\""
+        "QT_NO_KEYWORDS"
 )
 
 target_link_libraries(qtxdg-desktop-file-start

--- a/xdgiconloader/CMakeLists.txt
+++ b/xdgiconloader/CMakeLists.txt
@@ -34,6 +34,11 @@ configure_file(
     COPYONLY
 )
 
+target_compile_definitions(${QTXDGX_ICONLOADER_LIBRARY_NAME}
+    PRIVATE
+        "QT_NO_KEYWORDS"
+)
+
 target_include_directories(${QTXDGX_ICONLOADER_LIBRARY_NAME}
     INTERFACE
         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${QTXDGX_ICONLOADER_FILE_NAME}>"

--- a/xdgiconloader/plugin/CMakeLists.txt
+++ b/xdgiconloader/plugin/CMakeLists.txt
@@ -6,6 +6,10 @@ add_library(${QTXDGX_ICONENGINEPLUGIN_LIBRARY_NAME} MODULE
     ${xdgiconengineplugin_CPP_FILES}
 )
 
+target_compile_definitions(${QTXDGX_ICONENGINEPLUGIN_LIBRARY_NAME}
+    PRIVATE
+        "QT_NO_KEYWORDS"
+)
 target_link_libraries(${QTXDGX_ICONENGINEPLUGIN_LIBRARY_NAME}
     PUBLIC
         Qt5::Gui


### PR DESCRIPTION
Use Q_ macros instead of signals, slots, emit, foreach... to increase
compatibility with other libraries (Boost, GLib, etc).