### PR TITLE
Drop Q_FOREACH

### DIFF
--- a/qtxdg/xdgautostart.cpp
+++ b/qtxdg/xdgautostart.cpp
@@ -57,14 +57,14 @@ XdgDesktopFileList XdgAutoStart::desktopFileList(QStringList dirs, bool excludeH
 
     QSet<QString> processed;
     XdgDesktopFileList ret;
-    Q_FOREACH (const QString &dirName, dirs)
+    for (const QString &dirName : const_cast<const QStringList&>(dirs))
     {
         QDir dir(dirName);
         if (!dir.exists())
             continue;
 
         const QFileInfoList files = dir.entryInfoList(QStringList(QLatin1String("*.desktop")), QDir::Files | QDir::Readable);
-        Q_FOREACH (const QFileInfo &fi, files)
+        for (const QFileInfo &fi : files)
         {
             if (processed.contains(fi.fileName()))
                 continue;

--- a/qtxdg/xdgdesktopfile.cpp
+++ b/qtxdg/xdgdesktopfile.cpp
@@ -409,9 +409,9 @@ bool XdgDesktopFileData::startApplicationDetached(const XdgDesktopFile *q, const
     }
 
     bool nonDetach = false;
-    Q_FOREACH(const QString &s, nonDetachExecs)
+    for (const QString &s : nonDetachExecs)
     {
-        Q_FOREACH(const QString &a, args)
+        for (const QString &a : const_cast<const QStringList&>(args))
         {
             if (a.contains(s))
             {
@@ -953,7 +953,7 @@ QString expandEnvVariables(const QString str)
 QStringList expandEnvVariables(const QStringList strs)
 {
     QStringList res;
-    Q_FOREACH(const QString &s, strs)
+    for (const QString &s : strs)
         res << expandEnvVariables(s);
 
     return res;
@@ -969,9 +969,9 @@ QStringList XdgDesktopFile::expandExecString(const QStringList& urls) const
 
     QString execStr = value(execKey).toString();
     unEscapeExec(execStr);
-    QStringList tokens = parseCombinedArgString(execStr);
+    const QStringList tokens = parseCombinedArgString(execStr);
 
-    Q_FOREACH (QString token, tokens)
+    for (QString token : tokens)
     {
         // The parseCombinedArgString() splits the string by the space symbols,
         // we temporarily replaced them on the special characters.
@@ -1016,7 +1016,7 @@ QStringList XdgDesktopFile::expandExecString(const QStringList& urls) const
         // program. Local files may either be passed as file: URLs or as file path.
         if (token == QLatin1String("%U"))
         {
-            Q_FOREACH (const QString &s, urls)
+            for (const QString &s : urls)
             {
                 QUrl url(expandEnvVariables(s));
                 result << ((!url.toLocalFile().isEmpty()) ? url.toLocalFile() : QString::fromUtf8(url.toEncoded()));
@@ -1079,9 +1079,9 @@ bool checkTryExec(const QString& progName)
     if (progName.startsWith(QDir::separator()))
         return QFileInfo(progName).isExecutable();
 
-    QStringList dirs = QFile::decodeName(qgetenv("PATH")).split(QLatin1Char(':'));
+    const QStringList dirs = QFile::decodeName(qgetenv("PATH")).split(QLatin1Char(':'));
 
-    Q_FOREACH (const QString &dir, dirs)
+    for (const QString &dir : dirs)
     {
         if (QFileInfo(QDir(dir), progName).isExecutable())
             return true;
@@ -1103,7 +1103,7 @@ QString XdgDesktopFile::id(const QString &fileName, bool checkFileExists)
     QString id = f.absoluteFilePath();
     const QStringList dataDirs = XdgDirs::dataDirs();
 
-    Q_FOREACH(const QString &d, dataDirs) {
+    for (const QString &d : dataDirs) {
         if (id.startsWith(d)) {
             // remove only the first occurence
             id.replace(id.indexOf(d), d.size(), QString());
@@ -1211,7 +1211,8 @@ bool XdgDesktopFile::isSuitable(bool excludeHidden, const QString &environment) 
 
 QString expandDynamicUrl(QString url)
 {
-    Q_FOREACH(const QString &line, QProcess::systemEnvironment())
+    const QStringList env = QProcess::systemEnvironment();
+    for (const QString &line : env)
     {
         QString name = line.section(QLatin1Char('='), 0, 0);
         QString val =  line.section(QLatin1Char('='), 1);
@@ -1252,8 +1253,8 @@ QString findDesktopFile(const QString& dirName, const QString& desktopName)
         return fi.canonicalFilePath();
 
     // Working recursively ............
-    QFileInfoList dirs = dir.entryInfoList(QStringList(), QDir::Dirs | QDir::NoDotAndDotDot);
-    Q_FOREACH (const QFileInfo &d, dirs)
+    const QFileInfoList dirs = dir.entryInfoList(QStringList(), QDir::Dirs | QDir::NoDotAndDotDot);
+    for (const QFileInfo &d : dirs)
     {
         QString cn = d.canonicalFilePath();
         if (dirName != cn)
@@ -1273,7 +1274,7 @@ QString findDesktopFile(const QString& desktopName)
     QStringList dataDirs = XdgDirs::dataDirs();
     dataDirs.prepend(XdgDirs::dataHome(false));
 
-    Q_FOREACH (const QString &dirName, dataDirs)
+    for (const QString &dirName : const_cast<const QStringList&>(dataDirs))
     {
         QString f = findDesktopFile(dirName + QLatin1String("/applications"), desktopName);
         if (!f.isEmpty())
@@ -1461,8 +1462,8 @@ void XdgDesktopFileCache::initialize(const QString& dirName)
 
 
     // Working recursively ............
-    QFileInfoList files = dir.entryInfoList(QStringList(), QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot);
-    Q_FOREACH (const QFileInfo &f, files)
+    const QFileInfoList files = dir.entryInfoList(QStringList(), QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot);
+    for (const QFileInfo &f : files)
     {
         if (f.isDir())
         {
@@ -1480,9 +1481,9 @@ void XdgDesktopFileCache::initialize(const QString& dirName)
             m_fileCache.insert(f.absoluteFilePath(), df);
         }
 
-        QStringList mimes = df->value(mimeTypeKey).toString().split(QLatin1Char(';'), QString::SkipEmptyParts);
+        const QStringList mimes = df->value(mimeTypeKey).toString().split(QLatin1Char(';'), QString::SkipEmptyParts);
 
-        Q_FOREACH (const QString &mime, mimes)
+        for (const QString &mime : mimes)
         {
             int pref = df->value(initialPreferenceKey, 0).toInt();
             // We move the desktopFile forward in the list for this mime, so that
@@ -1523,7 +1524,7 @@ void loadMimeCacheDir(const QString& dirName, QHash<QString, QList<XdgDesktopFil
 
     // Working recursively ............
     const QFileInfoList files = dir.entryInfoList(QStringList(), QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot);
-    Q_FOREACH (const QFileInfo &f, files)
+    for (const QFileInfo &f : files)
     {
         if (f.isDir())
         {
@@ -1538,7 +1539,7 @@ void loadMimeCacheDir(const QString& dirName, QHash<QString, QList<XdgDesktopFil
 
         const QStringList mimes = df->value(mimeTypeKey).toString().split(QLatin1Char(';'), QString::SkipEmptyParts);
 
-        Q_FOREACH (const QString &mime, mimes)
+        for (const QString &mime : mimes)
         {
             int pref = df->value(initialPreferenceKey, 0).toInt();
             // We move the desktopFile forward in the list for this mime, so that
@@ -1582,7 +1583,7 @@ void XdgDesktopFileCache::initialize()
     QStringList dataDirs = XdgDirs::dataDirs();
     dataDirs.prepend(XdgDirs::dataHome(false));
 
-    Q_FOREACH (const QString &dirname, dataDirs)
+    for (const QString &dirname : const_cast<const QStringList&>(dataDirs))
     {
         initialize(dirname + QLatin1String("/applications"));
 //        loadMimeCacheDir(dirname + "/applications", m_defaultAppsCache);
@@ -1593,7 +1594,8 @@ QList<XdgDesktopFile*> XdgDesktopFileCache::getAppsOfCategory(const QString& cat
 {
     QList<XdgDesktopFile*> list;
     const QString _category = category.toUpper();
-    Q_FOREACH (XdgDesktopFile *desktopFile, instance().m_fileCache)
+    const QHash<QString, XdgDesktopFile*> fileCache = instance().m_fileCache;
+    for (XdgDesktopFile *desktopFile : fileCache)
     {
         QStringList categories = desktopFile->value(categoriesKey).toString().toUpper().split(QLatin1Char(';'));
         if (!categories.isEmpty() && (categories.contains(_category) || categories.contains(QLatin1String("X-") + _category)))
@@ -1614,7 +1616,7 @@ XdgDesktopFile* XdgDesktopFileCache::getDefaultApp(const QString& mimetype)
     // /usr/share/applications/mimeapps.list (in that order) for a default.
     QStringList dataDirs = XdgDirs::dataDirs();
     dataDirs.prepend(XdgDirs::dataHome(false));
-    Q_FOREACH(const QString &dataDir, dataDirs)
+    for (const QString &dataDir : const_cast<const QStringList&>(dataDirs))
     {
         QString defaultsListPath = dataDir + QLatin1String("/applications/mimeapps.list");
         if (QFileInfo::exists(defaultsListPath))
@@ -1628,7 +1630,8 @@ XdgDesktopFile* XdgDesktopFileCache::getDefaultApp(const QString& mimetype)
                 QVariant value = defaults.value(mimetype);
                 if (value.canConvert<QStringList>()) // A single string can also convert to a stringlist
                 {
-                    Q_FOREACH (const QString &desktopFileName, value.toStringList())
+                    const QStringList values = value.toStringList();
+                    for (const QString &desktopFileName : values)
                     {
                         XdgDesktopFile* desktopFile = XdgDesktopFileCache::getFile(desktopFileName);
                         if (desktopFile)

--- a/qtxdg/xdgdirs.cpp
+++ b/qtxdg/xdgdirs.cpp
@@ -336,7 +336,7 @@ QStringList XdgDirs::autostartDirs(const QString &postfix)
 {
     QStringList dirs;
     const QStringList s = configDirs();
-    Q_FOREACH(const QString &dir, s)
+    for (const QString &dir : s)
         dirs << QString::fromLatin1("%1/autostart").arg(dir) + postfix;
 
     return dirs;

--- a/qtxdg/xdgicon.cpp
+++ b/qtxdg/xdgicon.cpp
@@ -118,7 +118,7 @@ QIcon XdgIcon::fromTheme(const QString& iconName, const QIcon& fallback)
  ************************************************/
 QIcon XdgIcon::fromTheme(const QStringList& iconNames, const QIcon& fallback)
 {
-    Q_FOREACH (const QString &iconName, iconNames)
+    for (const QString &iconName : iconNames)
     {
         QIcon icon = fromTheme(iconName);
         if (!icon.isNull())

--- a/qtxdg/xdgmenu.cpp
+++ b/qtxdg/xdgmenu.cpp
@@ -412,7 +412,7 @@ QDomElement XdgMenu::findMenu(QDomElement& baseElement, const QString& path, boo
 
     const QStringList names = path.split(QLatin1Char('/'), QString::SkipEmptyParts);
     QDomElement el = baseElement;
-    Q_FOREACH (const QString &name, names)
+    for (const QString &name : names)
     {
         QDomElement p = el;
         el = d->mXml.createElement(QLatin1String("Menu"));
@@ -537,12 +537,12 @@ void XdgMenuPrivate::processDirectoryEntries(QDomElement& element, const QString
     dirs << parentDirs;
 
     bool found = false;
-    Q_FOREACH(const QString &file, files){
+    for (const QString &file : const_cast<const QStringList&>(files)){
         if (file.startsWith(QLatin1Char('/')))
             found = loadDirectoryFile(file, element);
         else
         {
-            Q_FOREACH (const QString &dir, dirs)
+            for (const QString &dir : const_cast<const QStringList&>(dirs))
             {
                 found = loadDirectoryFile(dir + QLatin1Char('/') + file, element);
                 if (found) break;
@@ -651,7 +651,7 @@ QString XdgMenu::getMenuFileName(const QString& baseName)
     const QStringList configDirs = XdgDirs::configDirs();
     QString menuPrefix = QString::fromLocal8Bit(qgetenv("XDG_MENU_PREFIX"));
 
-    Q_FOREACH(const QString &configDir, configDirs)
+    for (const QString &configDir : configDirs)
     {
         QFileInfo file(QString::fromLatin1("%1/menus/%2%3").arg(configDir, menuPrefix, baseName));
         if (file.exists())
@@ -669,9 +669,9 @@ QString XdgMenu::getMenuFileName(const QString& baseName)
     wellKnownFiles << QLatin1String("gnome-applications.menu");
     wellKnownFiles << QLatin1String("lxde-applications.menu");
 
-    Q_FOREACH(const QString &configDir, configDirs)
+    for (const QString &configDir : configDirs)
     {
-        Q_FOREACH (const QString &f, wellKnownFiles)
+        for (const QString &f : const_cast<const QStringList&>(wellKnownFiles))
         {
             QFileInfo file(QString::fromLatin1("%1/menus/%2").arg(configDir, f));
             if (file.exists())

--- a/qtxdg/xdgmenuapplinkprocessor.cpp
+++ b/qtxdg/xdgmenuapplinkprocessor.cpp
@@ -90,7 +90,8 @@ void XdgMenuApplinkProcessor::step1()
     }
 
     // Process childs menus ...............................
-    Q_FOREACH (XdgMenuApplinkProcessor* child, mChilds)
+
+    for (XdgMenuApplinkProcessor* child : const_cast<const QLinkedList<XdgMenuApplinkProcessor*>&>(mChilds))
         child->step1();
 }
 
@@ -100,7 +101,7 @@ void XdgMenuApplinkProcessor::step2()
     // Create AppLinks elements ...........................
     QDomDocument doc = mElement.ownerDocument();
 
-    Q_FOREACH (XdgMenuAppFileInfo* fileInfo, mSelected)
+    for (XdgMenuAppFileInfo* fileInfo : const_cast<const QLinkedList<XdgMenuAppFileInfo*>&>(mSelected))
     {
         if (mOnlyUnallocated && fileInfo->allocated())
             continue;
@@ -141,7 +142,7 @@ void XdgMenuApplinkProcessor::step2()
 
 
     // Process childs menus ...............................
-    Q_FOREACH (XdgMenuApplinkProcessor* child, mChilds)
+    for (XdgMenuApplinkProcessor* child : const_cast<const QLinkedList<XdgMenuApplinkProcessor*>&>(mChilds))
         child->step2();
 }
 
@@ -189,7 +190,7 @@ void XdgMenuApplinkProcessor::findDesktopFiles(const QString& dirName, const QSt
     mMenu->addWatchPath(dir.absolutePath());
     const QFileInfoList files = dir.entryInfoList(QStringList(QLatin1String("*.desktop")), QDir::Files);
 
-    Q_FOREACH (const QFileInfo &file, files)
+    for (const QFileInfo &file : files)
     {
         XdgDesktopFile* f = XdgDesktopFileCache::getFile(file.canonicalFilePath());
         if (f)
@@ -199,7 +200,7 @@ void XdgMenuApplinkProcessor::findDesktopFiles(const QString& dirName, const QSt
 
     // Working recursively ............
     const QFileInfoList dirs = dir.entryInfoList(QStringList(), QDir::Dirs | QDir::NoDotAndDotDot);
-    Q_FOREACH (const QFileInfo &d, dirs)
+    for (const QFileInfo &d : dirs)
     {
         QString dn = d.canonicalFilePath();
         if (dn != dirName)
@@ -242,7 +243,7 @@ bool XdgMenuApplinkProcessor::checkTryExec(const QString& progName)
 
     const QStringList dirs = QFile::decodeName(qgetenv("PATH")).split(QLatin1Char(':'));
 
-    Q_FOREACH (const QString &dir, dirs)
+    for (const QString &dir : dirs)
     {
         if (QFileInfo(QDir(dir), progName).isExecutable())
             return true;

--- a/qtxdg/xdgmenureader.cpp
+++ b/qtxdg/xdgmenureader.cpp
@@ -215,7 +215,7 @@ void XdgMenuReader::processMergeFileTag(QDomElement& element, QStringList* merge
         QString relativeName;
         QStringList configDirs = XdgDirs::configDirs();
 
-        Q_FOREACH (const QString &configDir, configDirs)
+        for (const QString &configDir : const_cast<const QStringList&>(configDirs))
         {
             if (mFileName.startsWith(configDir))
             {
@@ -236,7 +236,7 @@ void XdgMenuReader::processMergeFileTag(QDomElement& element, QStringList* merge
         if (relativeName.isEmpty())
             return;
 
-        Q_FOREACH (const QString &configDir, configDirs)
+        for (const QString &configDir : configDirs)
         {
             if (QFileInfo::exists(configDir + relativeName))
             {
@@ -295,7 +295,7 @@ void XdgMenuReader::processDefaultMergeDirsTag(QDomElement& element, QStringList
     QStringList dirs = XdgDirs::configDirs();
     dirs << XdgDirs::configHome();
 
-    Q_FOREACH (const QString &dir, dirs)
+    for (const QString &dir : const_cast<const QStringList&>(dirs))
     {
         mergeDir(QString::fromLatin1("%1/menus/%2-merged").arg(dir, menuBaseName), element, mergedFiles);
     }
@@ -329,7 +329,7 @@ void XdgMenuReader::processDefaultAppDirsTag(QDomElement& element)
     QStringList dirs = XdgDirs::dataDirs();
     dirs.prepend(XdgDirs::dataHome(false));
 
-    Q_FOREACH (const QString &dir, dirs)
+    for (const QString &dir : const_cast<const QStringList&> (dirs))
     {
         //qDebug() << "Add AppDir: " << dir + "/applications/";
         addDirTag(element, QLatin1String("AppDir"), dir + QLatin1String("/applications/"));
@@ -360,7 +360,7 @@ void XdgMenuReader::processDefaultDirectoryDirsTag(QDomElement& element)
     QStringList dirs = XdgDirs::dataDirs();
     dirs.prepend(XdgDirs::dataHome(false));
 
-    Q_FOREACH (const QString &dir, dirs)
+    for (const QString &dir : const_cast<const QStringList&>(dirs))
         addDirTag(element, QLatin1String("DirectoryDir"), dir + QLatin1String("/desktop-directories/"));
 }
 
@@ -379,8 +379,7 @@ void XdgMenuReader::addDirTag(QDomElement& previousElement, const QString& tagNa
     }
 }
 
-
-/************************************************
+/*
  If fileName is not an absolute path then the file to be merged should be located
  relative to the location of this menu file.
  ************************************************/
@@ -431,7 +430,7 @@ void XdgMenuReader::mergeDir(const QString& dirName, QDomElement& element, QStri
         QDir dir = QDir(dirInfo.canonicalFilePath());
         const QFileInfoList files = dir.entryInfoList(QStringList() << QLatin1String("*.menu"), QDir::Files | QDir::Readable);
 
-        Q_FOREACH (const QFileInfo &file, files)
+        for (const QFileInfo &file : files)
             mergeFile(file.canonicalFilePath(), element, mergedFiles);
     }
 }

--- a/qtxdg/xdgmimetype.cpp
+++ b/qtxdg/xdgmimetype.cpp
@@ -96,7 +96,7 @@ QString XdgMimeType::iconName() const
         names.append(QMimeType::iconName());
         names.append(QMimeType::genericIconName());
 
-        Q_FOREACH (const QString &s, names) {
+        for (const QString &s : const_cast<const QStringList&>(names)) {
             if (!XdgIcon::fromTheme(s).isNull()) {
                 dx->iconName = s;
                 break;

--- a/test/qtxdg_test.cpp
+++ b/test/qtxdg_test.cpp
@@ -47,15 +47,17 @@ void QtXdgTest::testDefaultApp()
 {
     QStringList mimedirs = XdgDirs::dataDirs();
     mimedirs.prepend(XdgDirs::dataHome(false));
-    Q_FOREACH (QString mimedir, mimedirs)
+    for (const QString &mimedir : const_cast<const QStringList&>(mimedirs))
     {
         QDir dir(mimedir + "/mime");
         qDebug() << dir.path();
         QStringList filters = (QStringList() << "*.xml");
-        Q_FOREACH(QFileInfo mediaDir, dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot))
+        const QFileInfoList &mediaDirs = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
+        for (const QFileInfo &mediaDir : mediaDirs)
         {
             qDebug() << "    " << mediaDir.fileName();
-            Q_FOREACH (QString mimeXmlFileName, QDir(mediaDir.absoluteFilePath()).entryList(filters, QDir::Files))
+            const QStringList mimeXmlFileNames = QDir(mediaDir.absoluteFilePath()).entryList(filters, QDir::Files);
+            for (const QString &mimeXmlFileName : mimeXmlFileNames)
             {
                 QString mimetype = mediaDir.fileName() + "/" + mimeXmlFileName.left(mimeXmlFileName.length() - 4);
                 QString xdg_utils_default = xdgUtilDefaultApp(mimetype);


### PR DESCRIPTION
Qt 5.9 deprecated it. Replaced with C++11 ranged for-loops.
We don't use qAsConst(). It was introduced in Qt 5.7. We don't require
Qt 5.7. qAsConst() replaced with const_cast<const T&>(t).