### PR TITLE
Backport support for Scale directory key according to Icon Theme spec

### DIFF
--- a/xdgiconloader/xdgiconloader_p.h
+++ b/xdgiconloader/xdgiconloader_p.h
@@ -86,7 +86,7 @@ private:
     bool hasIcon() const;
     void ensureLoaded();
     void virtual_hook(int id, void *data) Q_DECL_OVERRIDE;
-    QIconLoaderEngineEntry *entryForSize(const QSize &size);
+    QIconLoaderEngineEntry *entryForSize(const QSize &size, int scale = 1);
     XdgIconLoaderEngine(const XdgIconLoaderEngine &other);
     QThemeIconInfo m_info;
     QString m_iconName;


### PR DESCRIPTION
QIconLoader original commit:
http://code.qt.io/cgit/qt/qtbase.git/commit/src/gui/image?id=f299b565b5904e39a47b6133643448e46810f0ed

Implement support for Scale directory key according to Icon Theme spec

Qt already supports high DPI icons using the “@nx” approach, where the
device pixel ratio that the image was designed for is in the file
name. However, our implementation of the freedekstop.org Icon Theme
specification did not support the Scale directory key:

https://standards.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html#directory_layout

This meant that users creating icons via QIcon::fromTheme() did not
get high DPI support. This patch fixes that.

[ChangeLog][QtGui][QIcon] Implemented support for Scale directory key
according to Icon Theme Spec. Icons created via QIcon::fromTheme()
now have high DPI support by specifying the Scale in the appropriate
entry of the relevant index.theme file.

Task-number: QTBUG-49820
Change-Id: If442fbc551034166d88defe607109de1c6ca1d28
Reviewed-by: Paul Olav Tvete <paul.tvete@qt.io>
Reviewed-by: Shawn Rutledge <shawn.rutledge@qt.io>
Reviewed-by: Topi Reiniö <topi.reinio@qt.io>
Reviewed-by: Eirik Aavitsland <eirik.aavitsland@qt.io>