### PR TITLE
xdgiconloader: Cache ScalableFollowsColorEntry properly

### DIFF
--- a/xdgiconloader/xdgiconloader_p.h
+++ b/xdgiconloader/xdgiconloader_p.h
@@ -64,7 +64,6 @@ class XdgIconLoader;
 struct ScalableFollowsColorEntry : public ScalableEntry
 {
     QPixmap pixmap(const QSize &size, QIcon::Mode mode, QIcon::State state) Q_DECL_OVERRIDE;
-    QIcon svgSelectedIcon;
 };
 
 //class QIconLoaderEngine : public QIconEngine


### PR DESCRIPTION
..by using the QSvgIconEngine under the hood.

This was done previously in be58584d0e6c11feaa6929099885ff2a7d882401,
but was reverted by 81e6ffa52ff2ec6d6bcff7e936b6a7fe04c5bbdb (this
completely lacks any caching and does read/process file and generate
image for each pixmap() call).

In this commit we don't create the (private) QSvgIconEngine manually,
but use the operators <<, >> to achieve it. Thus reducing the chance
to break things with future Qt versions (the (de)serialization will
never change for requested QDataStream::Version).