### PR TITLE
Normalize signal/slot signatures

### DIFF
--- a/qtxdg/xdgdesktopfile.cpp
+++ b/qtxdg/xdgdesktopfile.cpp
@@ -463,7 +463,7 @@ bool XdgDesktopFileData::startApplicationDetached(const XdgDesktopFile *q, const
         if (started)
         {
             QProcess* proc = p.take(); //release the pointer(will be selfdestroyed upon finish)
-            QObject::connect(proc, SIGNAL(finished(int, QProcess::ExitStatus)), proc, SLOT(deleteLater()));
+            QObject::connect(proc, SIGNAL(finished(int,QProcess::ExitStatus)), proc, SLOT(deleteLater()));
         }
         return started;
     }


### PR DESCRIPTION
QObject::connect() brings a severe performance penalty when not using
normalized signatures. Signal lookup is first attempted with the signature
as-is, and if that fails QMetaObject::normalizedSignature() called.

That means, when using non-normalized signal/slot signatures, you not only
pay for a strcpy(), but also for a doomed-to-fail first lookup attempt.
Sure, connects are usually done during startup, and a profiler won’t show
you, but using non-normalized signatures is hereby firmly put into the
realm of premature pessimisation.

Reference:
https://marcmutz.wordpress.com/effective-qt/prefer-to-use-normalised-signalslot-signatures/