### PR TITLE
xdgiconloader: Add GTK cache revalidation

### DIFF
--- a/xdgiconloader/xdgiconloader.cpp
+++ b/xdgiconloader/xdgiconloader.cpp
@@ -148,8 +148,7 @@ QIconCacheGtkReader::QIconCacheGtkReader(const QString &dirName)
     // Note: The cache file can be (IS) removed and newly created during the
     // cache update. But we hold open file descriptor for the "old" removed
     // file. So we need to watch the changes and reopen/remap the file.
-    QObject::connect(static_cast<QFileSystemWatcher *>(gtkCachesWatcher), &QFileSystemWatcher::fileChanged
-            , static_cast<QFileSystemWatcher *>(gtkCachesWatcher), [this](const QString & path)
+    QObject::connect(gtkCachesWatcher(), &QFileSystemWatcher::fileChanged, &m_file, [this](const QString & path)
         {
             if (m_file.fileName() == path)
             {


### PR DESCRIPTION
In case an icon is added and the GTK cache is refreshed the already
running Qt application does not get the information from GTK cache.
That's because the cache file is changed (modified or deleted+newly
created), but the mapped memory used to read the file is not affected.

We will re-map the cache file for such situations to properly use the
cache also after the content change.